### PR TITLE
Fix: Encrypt Spotify refresh token on user login update

### DIFF
--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -43,7 +43,7 @@ def update_user_login_and_token(
     """
     db_user = get_user_by_spotify_id(db, spotify_id)
 
-    db_user.spotify_refresh_token = spotify_refresh_token  # updated
+    db_user.spotify_refresh_token = encrypt_token(spotify_refresh_token)
     db_user.last_login = datetime.now(timezone.utc)
     if display_name:
         db_user.display_name = display_name


### PR DESCRIPTION
🐛 Fix: Encrypt Spotify refresh token on user login update

## Problem
Spotify authentication was failing on subsequent logins with an **"Incorrect padding"** error.  
The root cause was that `update_user_login_and_token()` was storing the refresh token in plain text instead of encrypting it.

### Flow
- ✅ **First login**: `create_user()` → token encrypted → works  
- ❌ **Second login**: `update_user_login_and_token()` → token stored plain → decryption fails on next request

## Solution
Encrypt the refresh token in `update_user_login_and_token()` to match the behavior in `create_user()`.

```python
# Before
db_user.spotify_refresh_token = spotify_refresh_token

# After
db_user.spotify_refresh_token = encrypt_token(spotify_refresh_token)
