### PR TITLE
In memory cache for token refresh

### DIFF
--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -6,7 +6,7 @@ from backend.services import user_service
 from backend.models.user import User
 from backend.exceptions.custom_exceptions import UserNotFoundError
 
-async def get_current_user(
+def get_current_user(
     request: Request, 
     db: Session = Depends(get_db)
 ) -> User:

--- a/backend/routers/analytics.py
+++ b/backend/routers/analytics.py
@@ -60,68 +60,6 @@ async def get_spotify_access_token_for_authenticated_user(
             detail=f"Failed to obtain Spotify access token: {e}"
         )
 
-
-async def handle_spotify_api_call_with_retry(
-    spotify_api_func,
-    current_user: User,
-    db: Session,
-    *args,
-    **kwargs
-):
-    """
-    Wrapper function to handle Spotify API calls with automatic token refresh on 401.
-    
-    Args:
-        spotify_api_func: The Spotify API function to call
-        current_user: The authenticated user
-        db: Database session
-        *args, **kwargs: Arguments to pass to the spotify_api_func
-        
-    Returns:
-        The result from the Spotify API call
-        
-    Raises:
-        SpotifyAPIError: If the API call fails after retry
-    """
-    cache = get_token_cache()
-    
-    # Get the access token (might be cached)
-    access_token = await get_spotify_access_token_for_authenticated_user(current_user, db)
-    
-    try:
-        # Try the API call with current token
-        return await spotify_api_func(access_token, *args, **kwargs)
-        
-    except spotify_api_service.SpotifyAPIError as e:
-        # If we get a 401, the cached token might be invalid
-        if e.status_code == 401:
-            logger.warning(f"Got 401 from Spotify API for user {current_user.spotify_id}, invalidating cache and retrying")
-            
-            # Invalidate cached token
-            cache.invalidate(current_user.spotify_id)
-            
-            # Force refresh a new token
-            try:
-                token_data = await auth_service.refresh_user_spotify_access_token(db, current_user.spotify_id)
-                new_access_token = token_data["access_token"]
-                expires_in = token_data.get("expires_in", 3600)
-                
-                # Cache the new token
-                cache.set(current_user.spotify_id, new_access_token, expires_in)
-                
-                # Retry the API call with new token
-                return await spotify_api_func(new_access_token, *args, **kwargs)
-                
-            except Exception as refresh_error:
-                logger.error(f"Failed to refresh token after 401: {refresh_error}")
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Failed to refresh Spotify access token. Please re-authenticate."
-                )
-        
-        # For other errors, re-raise
-        raise
-
 @router.get("/top-items/{item_type}", summary="Get a user's top artists or tracks")
 async def get_user_top_items_endpoint(
     item_type: SpotifyTopItemType,

--- a/backend/routers/analytics.py
+++ b/backend/routers/analytics.py
@@ -5,10 +5,13 @@ from backend.services import auth_service, spotify_api_service
 from backend.exceptions.custom_exceptions import UserNotFoundError, RefreshTokenMissingError
 from backend.core.dependencies import get_current_user
 from backend.models.user import User
+from backend.services.token_cache import get_token_cache
 from typing import Dict, Any
 from backend.services.spotify_api_service import SpotifyTopItemType, SpotifyTimeRange
 from backend.services.spotify_api_service import DEFAULT_SPOTIFY_LIMIT, MAX_SPOTIFY_LIMIT
+import logging
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/analytics", tags=["Analytics"])
 
 async def get_spotify_access_token_for_authenticated_user(
@@ -17,12 +20,29 @@ async def get_spotify_access_token_for_authenticated_user(
 ) -> str:
     """
     Dependency that retrieves a valid Spotify access token for the authenticated user.
-    It uses the refresh token stored in the database.
+    Uses cached token if available and valid, otherwise refreshes it.
     """
+    cache = get_token_cache()
+    
+    # Try to get cached token first
+    cached_token = cache.get(current_user.spotify_id)
+    if cached_token:
+        logger.debug(f"Using cached Spotify token for user {current_user.spotify_id}")
+        return cached_token
+    
+    # No valid cached token, refresh it
+    logger.info(f"Refreshing Spotify token for user {current_user.spotify_id}")
     try:
-        # Refresh the user's Spotify access token using the stored refresh token.
+        # Refresh the user's Spotify access token using the stored refresh token
         token_data = await auth_service.refresh_user_spotify_access_token(db, current_user.spotify_id)
-        return token_data["access_token"]
+        access_token = token_data["access_token"]
+        expires_in = token_data.get("expires_in", 3600)  # Default to 1 hour if not provided
+        
+        # Cache the new token
+        cache.set(current_user.spotify_id, access_token, expires_in)
+        
+        return access_token
+        
     except UserNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -34,11 +54,73 @@ async def get_spotify_access_token_for_authenticated_user(
             detail=f"Refresh token missing for user '{current_user.spotify_id}'. Please re-authenticate with Spotify."
         )
     except Exception as e:
+        logger.error(f"Failed to obtain Spotify access token: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to obtain Spotify access token: {e}"
         )
 
+
+async def handle_spotify_api_call_with_retry(
+    spotify_api_func,
+    current_user: User,
+    db: Session,
+    *args,
+    **kwargs
+):
+    """
+    Wrapper function to handle Spotify API calls with automatic token refresh on 401.
+    
+    Args:
+        spotify_api_func: The Spotify API function to call
+        current_user: The authenticated user
+        db: Database session
+        *args, **kwargs: Arguments to pass to the spotify_api_func
+        
+    Returns:
+        The result from the Spotify API call
+        
+    Raises:
+        SpotifyAPIError: If the API call fails after retry
+    """
+    cache = get_token_cache()
+    
+    # Get the access token (might be cached)
+    access_token = await get_spotify_access_token_for_authenticated_user(current_user, db)
+    
+    try:
+        # Try the API call with current token
+        return await spotify_api_func(access_token, *args, **kwargs)
+        
+    except spotify_api_service.SpotifyAPIError as e:
+        # If we get a 401, the cached token might be invalid
+        if e.status_code == 401:
+            logger.warning(f"Got 401 from Spotify API for user {current_user.spotify_id}, invalidating cache and retrying")
+            
+            # Invalidate cached token
+            cache.invalidate(current_user.spotify_id)
+            
+            # Force refresh a new token
+            try:
+                token_data = await auth_service.refresh_user_spotify_access_token(db, current_user.spotify_id)
+                new_access_token = token_data["access_token"]
+                expires_in = token_data.get("expires_in", 3600)
+                
+                # Cache the new token
+                cache.set(current_user.spotify_id, new_access_token, expires_in)
+                
+                # Retry the API call with new token
+                return await spotify_api_func(new_access_token, *args, **kwargs)
+                
+            except Exception as refresh_error:
+                logger.error(f"Failed to refresh token after 401: {refresh_error}")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Failed to refresh Spotify access token. Please re-authenticate."
+                )
+        
+        # For other errors, re-raise
+        raise
 
 @router.get("/top-items/{item_type}", summary="Get a user's top artists or tracks")
 async def get_user_top_items_endpoint(
@@ -60,7 +142,6 @@ async def get_user_top_items_endpoint(
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"An unexpected error occurred: {str(e)}")
 
-
 @router.get("/playlists", summary="Get a user's playlists")
 async def get_user_playlists_endpoint(
     limit: int = Query(DEFAULT_SPOTIFY_LIMIT, ge=1, le=MAX_SPOTIFY_LIMIT, description=f"The number of playlists to return. Default: {DEFAULT_SPOTIFY_LIMIT}. Minimum: 1. Maximum: {MAX_SPOTIFY_LIMIT}."),
@@ -77,7 +158,6 @@ async def get_user_playlists_endpoint(
         raise HTTPException(status_code=e.status_code or status.HTTP_500_INTERNAL_SERVER_ERROR, detail=e.message)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"An unexpected error occurred: {str(e)}")
-
 
 @router.get("/recently-played", summary="Get a user's recently played tracks")
 async def get_user_recently_played_endpoint(

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, status
 from backend.core.config import settings
 from backend.core.dependencies import get_current_user
 from backend.models.user import User
+from backend.services.token_cache import get_token_cache
 import logging 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -126,19 +127,21 @@ async def refresh_token(
             detail="Invalid or expired refresh token"
         )
 
-
 @router.post("/logout")
 @limiter.limit("10/minute")
 async def logout(
     request: Request,
     response: Response,
-    current_user: User = Depends(get_current_user)  # Verify user is authenticated
+    current_user: User = Depends(get_current_user)
 ):
     """
-    Logout user by clearing authentication cookies.
+    Logout user by clearing authentication cookies and cached tokens.
     Works for both cookie-based and header-based authentication.
     """
     try:
+        cache = get_token_cache()
+        cache.invalidate(current_user.spotify_id)
+        
         logger.info(f"User {current_user.spotify_id} logged out")
         
         # Clear cookies if they exist
@@ -169,7 +172,6 @@ async def logout(
         logger.error(f"Logout error: {str(e)}")
         # Still return success to prevent information leakage
         return {"message": "Logged out successfully"}
-
 
 @router.get("/verify")
 @limiter.limit("30/minute")

--- a/backend/services/token_cache.py
+++ b/backend/services/token_cache.py
@@ -1,0 +1,82 @@
+"""
+Token caching module for Spotify access tokens.
+Caches tokens in memory with expiry tracking to avoid unnecessary refreshes.
+"""
+from typing import Optional, Dict
+from datetime import datetime, timedelta, timezone
+import threading
+
+class TokenCache:
+    """
+    Thread-safe in-memory cache for Spotify access tokens.
+    Stores tokens with expiry times to minimize API calls.
+    """
+    
+    def __init__(self):
+        self._cache: Dict[str, dict] = {}
+        self._lock = threading.Lock()
+    
+    def get(self, user_id: str) -> Optional[str]:
+        """
+        Retrieve a valid access token from cache.
+        
+        Args:
+            user_id: The user's ID (spotify_id or internal ID)
+            
+        Returns:
+            Valid access token if cached and not expired, None otherwise
+        """
+        with self._lock:
+            if user_id not in self._cache:
+                return None
+            
+            cached_data = self._cache[user_id]
+            
+            # Check if token has expired (with 60 second buffer)
+            if datetime.now(timezone.utc) >= cached_data['expires_at']:
+                # Token expired, remove from cache
+                del self._cache[user_id]
+                return None
+            
+            return cached_data['access_token']
+    
+    def set(self, user_id: str, access_token: str, expires_in: int):
+        """
+        Store an access token in cache with expiry time.
+        
+        Args:
+            user_id: The user's ID (spotify_id or internal ID)
+            access_token: The Spotify access token to cache
+            expires_in: Token lifetime in seconds (typically 3600)
+        """
+        with self._lock:
+            # Subtract 60 seconds buffer to ensure we refresh before actual expiry
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in - 60)
+            
+            self._cache[user_id] = {
+                'access_token': access_token,
+                'expires_at': expires_at
+            }
+    
+    def invalidate(self, user_id: str):
+        """
+        Remove a token from cache (e.g., after logout or token revocation).
+        
+        Args:
+            user_id: The user's ID (spotify_id or internal ID)
+        """
+        with self._lock:
+            if user_id in self._cache:
+                del self._cache[user_id]
+    
+    def clear(self):
+        """Clear all cached tokens."""
+        with self._lock:
+            self._cache.clear()
+
+# Global cache instance
+_token_cache = TokenCache()
+
+def get_token_cache() -> TokenCache:
+    """Get the global token cache instance."""
+    return _token_cache


### PR DESCRIPTION
## 🚀 Improve Spotify API Performance with Token Caching

This PR introduces **Spotify access token caching**, eliminating unnecessary token refreshes and significantly improving performance and API efficiency.

---

## 🔍 Comparison

### ❌ 1 — WITHOUT Caching (Old Code)
```
17:52:17 - GET /analytics/recently-played
17:52:18 - POST https://accounts.spotify.com/api/token ← Refresh token
17:52:18 - GET recently-played
Duration: 1.466s

17:52:24 - GET /analytics/playlists
17:52:24 - POST https://accounts.spotify.com/api/token ← Refresh token AGAIN
17:52:25 - GET playlists
Duration: 1.395s

17:52:30 - GET /analytics/top-items/artists
17:52:31 - POST https://accounts.spotify.com/api/token ← Refresh token AGAIN
17:52:32 - GET top artists
Duration: 1.590s
```

**3 requests = 3 token refreshes** ❌

---

### ✅ 2 — WITH Caching (New Code)
```
17:54:39 - GET /analytics/top-items/artists
17:54:39 - INFO - Refreshing Spotify token ← Refresh token (first time)
17:54:40 - POST https://accounts.spotify.com/api/token
17:54:41 - GET top artists
Duration: 1.818s

17:54:48 - GET /analytics/playlists
17:54:48 - GET playlists ← NO token refresh (cached)
Duration: 0.540s

17:54:55 - GET /analytics/recently-played
17:54:56 - GET recently-played ← NO token refresh (cached)
Duration: 0.546s
```

**3 requests = 1 token refresh** ✅

---

## 📊 Key Differences

| Metric | Without Caching | With Caching | Improvement |
|------|-----------------|--------------|-------------|
| Token Refreshes | 3 (every request) | 1 (first request only) | **67% reduction** |
| First Request | 1.466s | 1.818s | Expected (refresh required) |
| Second Request | 1.395s | **0.540s** | **61% faster** |
| Third Request | 1.590s | **0.546s** | **66% faster** |
| POST /api/token Calls | 3 | 1 | **Saved 2 API calls** |

---

## 📈 Visual Comparison

### WITHOUT Caching
```
Request 1 → [Refresh Token] → [Get Data] → 1.5s
Request 2 → [Refresh Token] → [Get Data] → 1.4s
Request 3 → [Refresh Token] → [Get Data] → 1.6s
```
Total: ~4.5s, 3 token refreshes


### WITH Caching
```
Request 1 → [Refresh Token] → [Get Data] → [Cache Token] → 1.8s
Request 2 → [Use Cached Token] → [Get Data] → 0.5s ⚡
Request 3 → [Use Cached Token] → [Get Data] → 0.5s ⚡
```
Total: ~2.8s, 1 token refresh


---

## 🔎 The Smoking Gun

**Before:**
```
POST https://accounts.spotify.com/api/token
POST https://accounts.spotify.com/api/token
POST https://accounts.spotify.com/api/token
```

**After:**
```
POST https://accounts.spotify.com/api/token ← Only once!
```

(Subsequent requests reuse the cached token.)

---

## ✅ Summary

- ✅ Token caching works as intended  
- ✅ First request refreshes and caches the token  
- ✅ Subsequent requests reuse the cached token  
- ✅ Cached requests are **60–65% faster**  
- ✅ **67% fewer calls** to Spotify’s token endpoint  

This change improves performance, reduces external API load, and increases overall reliability of S