### PR TITLE
Fix(auth): Add CSRF state validation and JWT token type enforcement

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -52,10 +52,18 @@ All endpoints are rate-limited to prevent abuse. Limits vary by endpoint.
     cookie_domain: Optional[str] = Field(default=None, alias="COOKIE_DOMAIN")
 
     # Cookie Expiration Times (in seconds)
-    oauth_state_max_age: int = Field(default=300, alias="OAUTH_STATE_MAX_AGE")  # 300 seconds = 5 minutes
-    access_token_max_age: int = Field(default=3600, alias="ACCESS_TOKEN_MAX_AGE")   # 3600 seconds = 1 hour
-    refresh_token_max_age: int = Field(default=2592000, alias="REFRESH_TOKEN_MAX_AGE")  # 2592000 seconds = 30 days
-    
+    oauth_state_max_age: int = Field(default=300, alias="OAUTH_STATE_MAX_AGE")  # 5 minutes
+
+    @property
+    def access_token_max_age(self) -> int:
+        """Cookie lifetime matches the JWT lifetime exactly."""
+        return self.access_token_expire_minutes * 60
+
+    @property
+    def refresh_token_max_age(self) -> int:
+        """Cookie lifetime matches the JWT lifetime exactly."""
+        return self.refresh_token_expire_days * 86400
+
     # Database
     database_url: Optional[str] = Field(default=None, alias="DATABASE_URL")
     

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -50,6 +50,11 @@ All endpoints are rate-limited to prevent abuse. Limits vary by endpoint.
     # CORS and Cookies
     frontend_url: str = Field(default="http://127.0.0.1:5173", alias="FRONTEND_URL")
     cookie_domain: Optional[str] = Field(default=None, alias="COOKIE_DOMAIN")
+
+    # Cookie Expiration Times (in seconds)
+    oauth_state_max_age: int = Field(default=300, alias="OAUTH_STATE_MAX_AGE")  # 300 seconds = 5 minutes
+    access_token_max_age: int = Field(default=3600, alias="ACCESS_TOKEN_MAX_AGE")   # 3600 seconds = 1 hour
+    refresh_token_max_age: int = Field(default=2592000, alias="REFRESH_TOKEN_MAX_AGE")  # 2592000 seconds = 30 days
     
     # Database
     database_url: Optional[str] = Field(default=None, alias="DATABASE_URL")

--- a/backend/core/jwt_utils.py
+++ b/backend/core/jwt_utils.py
@@ -4,38 +4,76 @@ from jose import JWTError, jwt
 from fastapi import HTTPException, status
 from backend.core.config import settings
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.now(timezone.utc) + expires_delta
     else:
         expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
-    to_encode.update({"exp": expire, "iat": datetime.now(timezone.utc)})
-    encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
-    return encoded_jwt
+    to_encode.update({
+        "exp": expire,
+        "iat": datetime.now(timezone.utc),
+        "type": "access",       # <-- type claim added
+    })
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 
-def decode_access_token(token: str):
+
+def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
+    to_encode.update({
+        "exp": expire,
+        "iat": datetime.now(timezone.utc),
+        "type": "refresh",      # <-- type claim added
+    })
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
+
+
+def decode_access_token(token: str) -> dict:
+    """
+    Decodes and validates an access token.
+    Raises 401 if the token is invalid or is not an access token.
+    """
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
-        return payload
     except JWTError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
-def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    if payload.get("type") != "access":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token type",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return payload
+
+
+def decode_refresh_token(token: str) -> dict:
     """
-    Generates a JWT refresh token for the app.
-    Typically longer-lived than access tokens.
+    Decodes and validates a refresh token.
+    Raises 401 if the token is invalid or is not a refresh token.
+    This is intentionally separate from decode_access_token so the two
+    token types can never be used interchangeably.
     """
-    to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
-    else:
-        expire = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
-    
-    to_encode.update({"exp": expire, "iat": datetime.now(timezone.utc)})
-    encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
-    return encoded_jwt
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if payload.get("type") != "refresh":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token type",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return payload

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,122 +1,145 @@
-from fastapi import APIRouter, Depends, Response, Request
+import secrets
+import logging
+
+from fastapi import APIRouter, Depends, Response, Request, HTTPException, status
+from fastapi.responses import RedirectResponse, JSONResponse
 from sqlalchemy.orm import Session
-from fastapi.responses import RedirectResponse
+
 from backend.services import auth_service, spotify_auth_service
 from backend.database.connection import get_db
 from backend.database.redis import get_redis, RedisTokenCache
 from backend.core.rate_limiter import limiter
-from fastapi import HTTPException, status
 from backend.core.config import settings
 from backend.core.dependencies import get_current_user
 from backend.models.user import User
-import logging
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/auth", tags=["Authentication"])
 
+# How long the oauth_state cookie lives (seconds).
+# Must be long enough for the user to approve on Spotify but short enough
+# to limit the replay window.
+_STATE_COOKIE_MAX_AGE = 300
+
+
 @router.get("/spotify/login")
 @limiter.limit("10/minute")
-async def spotify_login(
-    request: Request,
-):
-    """Initiate Spotify OAuth flow"""
-    auth_url = spotify_auth_service.get_authorize_url()
-    return {"auth_url": auth_url}
+async def spotify_login(request: Request):
+    """
+    Initiate Spotify OAuth flow.
+    Generates a cryptographically random state value, stores it in a
+    short-lived httpOnly cookie, and returns the Spotify auth URL.
+    """
+    state = secrets.token_urlsafe(16)
+    auth_url = spotify_auth_service.get_authorize_url(state)
+
+    response = JSONResponse({"auth_url": auth_url})
+    response.set_cookie(
+        key="oauth_state",
+        value=state,
+        max_age=_STATE_COOKIE_MAX_AGE,
+        httponly=True,
+        samesite="lax",         # lax so the cookie is sent on the redirect back
+        secure=settings.cookie_secure,
+        domain=settings.cookie_domain,
+    )
+    return response
+
 
 @router.get("/spotify/callback")
 @limiter.limit("5/minute")
 async def spotify_callback(
     request: Request,
     code: str,
-    db: Session = Depends(get_db)
+    state: str,                 # Spotify echoes the state we sent
+    db: Session = Depends(get_db),
 ):
-    """Handle Spotify OAuth callback"""
-    try:
-        access_token, refresh_token = await auth_service.handle_spotify_callback(
-            code, db
-        )
+    """Handle Spotify OAuth callback."""
 
-        redirect = RedirectResponse(
-            url=f"{settings.frontend_url}/dashboard"
+    # ── CSRF guard ──────────────────────────────────────────────────────────
+    stored_state = request.cookies.get("oauth_state")
+    if not state or not stored_state or state != stored_state:
+        logger.warning("OAuth state mismatch — possible CSRF attempt")
+        return RedirectResponse(
+            url=f"{settings.frontend_url}/login?error=state_mismatch"
         )
+    # ────────────────────────────────────────────────────────────────────────
+
+    try:
+        access_token, refresh_token = await auth_service.handle_spotify_callback(code, db)
 
         cookie_config = {
             "httponly": True,
             "samesite": settings.cookie_samesite,
             "secure": settings.cookie_secure,
             "domain": settings.cookie_domain,
+            "path": "/",
         }
 
-        redirect.set_cookie(
-            key="access_token",
-            value=access_token,
-            max_age=3600,
-            **cookie_config
+        redirect = RedirectResponse(url=f"{settings.frontend_url}/dashboard")
+
+        # Clear the one-time state cookie now that it has been consumed
+        redirect.delete_cookie(
+            "oauth_state",
+            httponly=True,
+            samesite="lax",
+            secure=settings.cookie_secure,
+            domain=settings.cookie_domain,
         )
 
-        redirect.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            max_age=2592000,
-            **cookie_config
-        )
+        redirect.set_cookie(key="access_token",  value=access_token,  max_age=3600,     **cookie_config)
+        redirect.set_cookie(key="refresh_token", value=refresh_token, max_age=2592000,  **cookie_config)
 
         return redirect
 
     except Exception as e:
         logger.error(f"Spotify callback error: {str(e)}")
-        return RedirectResponse(
-            url=f"{settings.frontend_url}/login?error=auth_failed"
-        )
+        return RedirectResponse(url=f"{settings.frontend_url}/login?error=auth_failed")
+
 
 @router.post("/refresh")
 @limiter.limit("20/minute")
 async def refresh_token(
     request: Request,
     response: Response,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     """
     Refresh the access token using the refresh token from cookie or header.
-    Returns new access token and optionally sets it in cookies.
+    Returns a new access token and optionally sets it in cookies.
     """
-    # Extract refresh token (similar to get_current_user logic)
-    refresh_token = None
+    refresh_token_value = None
 
     auth_header = request.headers.get("Authorization")
     if auth_header and auth_header.startswith("Bearer "):
-        refresh_token = auth_header.split(" ")[1]
+        refresh_token_value = auth_header.split(" ")[1]
 
-    if not refresh_token:
-        refresh_token = request.cookies.get("refresh_token")
+    if not refresh_token_value:
+        refresh_token_value = request.cookies.get("refresh_token")
 
-    if not refresh_token:
+    if not refresh_token_value:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token missing",
         )
 
     try:
-        new_tokens = await auth_service.refresh_access_token(refresh_token)
+        new_tokens = await auth_service.refresh_access_token(refresh_token_value)
 
         if request.cookies.get("refresh_token"):
-            cookie_config = {
-                "httponly": True,
-                "samesite": settings.cookie_samesite,
-                "secure": settings.cookie_secure,
-                "domain": settings.cookie_domain,
-            }
-
             response.set_cookie(
                 key="access_token",
                 value=new_tokens["access_token"],
                 max_age=3600,
-                **cookie_config
+                httponly=True,
+                samesite=settings.cookie_samesite,
+                secure=settings.cookie_secure,
+                domain=settings.cookie_domain,
+                path="/",
             )
 
         logger.info("Access token refreshed successfully")
-
         return {
             "message": "Token refreshed successfully",
             "access_token": new_tokens["access_token"],
@@ -130,6 +153,7 @@ async def refresh_token(
             detail="Invalid or expired refresh token",
         )
 
+
 @router.post("/logout")
 @limiter.limit("10/minute")
 async def logout(
@@ -139,28 +163,27 @@ async def logout(
     redis_client=Depends(get_redis),
 ):
     try:
-        # Only attempt cache invalidation if Redis is available
         if redis_client:
             cache = RedisTokenCache(redis_client)
             await cache.invalidate_token(current_user.spotify_id)
-            logger.info(f"User {current_user.spotify_id} logged out (Cache cleared)")
+            logger.info(f"User {current_user.spotify_id} logged out (cache cleared)")
         else:
-            logger.info(f"User {current_user.spotify_id} logged out (Cache bypass - Redis down)")
-
+            logger.info(f"User {current_user.spotify_id} logged out (cache bypass — Redis down)")
     except Exception as e:
         logger.error(f"Logout cache error (non-fatal): {str(e)}")
-        # We continue so cookies are still deleted
 
     cookie_config = {
         "httponly": True,
         "samesite": settings.cookie_samesite,
         "secure": settings.cookie_secure,
         "domain": settings.cookie_domain,
+        "path": "/",            # must match the path used when the cookie was set
     }
-    response.delete_cookie("access_token", **cookie_config)
+    response.delete_cookie("access_token",  **cookie_config)
     response.delete_cookie("refresh_token", **cookie_config)
 
     return {"message": "Logged out successfully"}
+
 
 @router.get("/verify")
 @limiter.limit("30/minute")
@@ -168,10 +191,7 @@ async def verify_token(
     request: Request,
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Verify if the current access token is valid.
-    Useful for frontend to check authentication status.
-    """
+    """Verify if the current access token is valid."""
     return {
         "authenticated": True,
         "user_id": current_user.id,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,5 +1,6 @@
 import secrets
 import logging
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Response, Request, HTTPException, status
 from fastapi.responses import RedirectResponse, JSONResponse
@@ -47,7 +48,7 @@ async def spotify_login(request: Request):
 async def spotify_callback(
     request: Request,
     code: str,
-    state: str,                 # Spotify echoes the state we sent
+    state: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
     """Handle Spotify OAuth callback."""
@@ -56,9 +57,11 @@ async def spotify_callback(
     stored_state = request.cookies.get("oauth_state")
     if not state or not stored_state or not secrets.compare_digest(state, stored_state):
         logger.warning("OAuth state mismatch — possible CSRF attempt")
-        return RedirectResponse(
+        response = RedirectResponse(
             url=f"{settings.frontend_url}/login?error=state_mismatch"
         )
+        response.delete_cookie("oauth_state", path="/", domain=settings.cookie_domain)
+        return response
     # ────────────────────────────────────────────────────────────────────────
 
     try:
@@ -74,24 +77,22 @@ async def spotify_callback(
 
         redirect = RedirectResponse(url=f"{settings.frontend_url}/dashboard")
 
-        # Clear the one-time state cookie now that it has been consumed
         redirect.delete_cookie(
             "oauth_state",
             path="/",
             domain=settings.cookie_domain,
         )
 
-        # Replaced magic numbers with settings
         redirect.set_cookie(
-            key="access_token",  
-            value=access_token,  
-            max_age=settings.access_token_max_age,  
+            key="access_token",
+            value=access_token,
+            max_age=settings.access_token_max_age,
             **cookie_config
         )
         redirect.set_cookie(
-            key="refresh_token", 
-            value=refresh_token, 
-            max_age=settings.refresh_token_max_age, 
+            key="refresh_token",
+            value=refresh_token,
+            max_age=settings.refresh_token_max_age,
             **cookie_config
         )
 
@@ -135,7 +136,7 @@ async def refresh_token(
             response.set_cookie(
                 key="access_token",
                 value=new_tokens["access_token"],
-                max_age=settings.access_token_max_age,  # Replaced magic number
+                max_age=settings.access_token_max_age,
                 httponly=True,
                 samesite=settings.cookie_samesite,
                 secure=settings.cookie_secure,
@@ -176,8 +177,6 @@ async def logout(
     except Exception as e:
         logger.error(f"Logout cache error (non-fatal): {str(e)}")
 
-    # delete_cookie only reliably accepts path and domain; httponly/samesite/secure
-    # are ignored by browsers on cookie deletion and not supported by all frameworks.
     response.delete_cookie("access_token",  path="/", domain=settings.cookie_domain)
     response.delete_cookie("refresh_token", path="/", domain=settings.cookie_domain)
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -59,7 +59,7 @@ async def spotify_callback(
 
     # ── CSRF guard ──────────────────────────────────────────────────────────
     stored_state = request.cookies.get("oauth_state")
-    if not state or not stored_state or state != stored_state:
+    if not state or not stored_state or not secrets.compare_digest(state, stored_state):
         logger.warning("OAuth state mismatch — possible CSRF attempt")
         return RedirectResponse(
             url=f"{settings.frontend_url}/login?error=state_mismatch"

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -43,6 +43,7 @@ async def spotify_login(request: Request):
         samesite="lax",         # lax so the cookie is sent on the redirect back
         secure=settings.cookie_secure,
         domain=settings.cookie_domain,
+        path="/",
     )
     return response
 
@@ -82,9 +83,7 @@ async def spotify_callback(
         # Clear the one-time state cookie now that it has been consumed
         redirect.delete_cookie(
             "oauth_state",
-            httponly=True,
-            samesite="lax",
-            secure=settings.cookie_secure,
+            path="/",
             domain=settings.cookie_domain,
         )
 
@@ -172,15 +171,10 @@ async def logout(
     except Exception as e:
         logger.error(f"Logout cache error (non-fatal): {str(e)}")
 
-    cookie_config = {
-        "httponly": True,
-        "samesite": settings.cookie_samesite,
-        "secure": settings.cookie_secure,
-        "domain": settings.cookie_domain,
-        "path": "/",            # must match the path used when the cookie was set
-    }
-    response.delete_cookie("access_token",  **cookie_config)
-    response.delete_cookie("refresh_token", **cookie_config)
+    # delete_cookie only reliably accepts path and domain; httponly/samesite/secure
+    # are ignored by browsers on cookie deletion and not supported by all frameworks.
+    response.delete_cookie("access_token",  path="/", domain=settings.cookie_domain)
+    response.delete_cookie("refresh_token", path="/", domain=settings.cookie_domain)
 
     return {"message": "Logged out successfully"}
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -17,12 +17,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/auth", tags=["Authentication"])
 
-# How long the oauth_state cookie lives (seconds).
-# Must be long enough for the user to approve on Spotify but short enough
-# to limit the replay window.
-_STATE_COOKIE_MAX_AGE = 300
-
-
 @router.get("/spotify/login")
 @limiter.limit("10/minute")
 async def spotify_login(request: Request):
@@ -38,7 +32,7 @@ async def spotify_login(request: Request):
     response.set_cookie(
         key="oauth_state",
         value=state,
-        max_age=_STATE_COOKIE_MAX_AGE,
+        max_age=settings.oauth_state_max_age,
         httponly=True,
         samesite="lax",         # lax so the cookie is sent on the redirect back
         secure=settings.cookie_secure,
@@ -87,8 +81,19 @@ async def spotify_callback(
             domain=settings.cookie_domain,
         )
 
-        redirect.set_cookie(key="access_token",  value=access_token,  max_age=3600,     **cookie_config)
-        redirect.set_cookie(key="refresh_token", value=refresh_token, max_age=2592000,  **cookie_config)
+        # Replaced magic numbers with settings
+        redirect.set_cookie(
+            key="access_token",  
+            value=access_token,  
+            max_age=settings.access_token_max_age,  
+            **cookie_config
+        )
+        redirect.set_cookie(
+            key="refresh_token", 
+            value=refresh_token, 
+            max_age=settings.refresh_token_max_age, 
+            **cookie_config
+        )
 
         return redirect
 
@@ -130,7 +135,7 @@ async def refresh_token(
             response.set_cookie(
                 key="access_token",
                 value=new_tokens["access_token"],
-                max_age=3600,
+                max_age=settings.access_token_max_age,  # Replaced magic number
                 httponly=True,
                 samesite=settings.cookie_samesite,
                 secure=settings.cookie_secure,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -48,25 +48,22 @@ async def spotify_login(request: Request):
 async def spotify_callback(
     request: Request,
     code: str,
-    state: Optional[str] = None,
+    state: str,
     db: Session = Depends(get_db),
 ):
-    """Handle Spotify OAuth callback."""
-
-    # ── CSRF guard ──────────────────────────────────────────────────────────
+    # 1. CSRF Check: Compare incoming state to the one in our cookie
     stored_state = request.cookies.get("oauth_state")
-    if not state or not stored_state or not secrets.compare_digest(state, stored_state):
-        logger.warning("OAuth state mismatch — possible CSRF attempt")
-        response = RedirectResponse(
-            url=f"{settings.frontend_url}/login?error=state_mismatch"
-        )
-        response.delete_cookie("oauth_state", path="/", domain=settings.cookie_domain)
-        return response
-    # ────────────────────────────────────────────────────────────────────────
+    if not secrets.compare_digest(state, stored_state or ""):
+        logger.warning("OAuth state mismatch")
+        return RedirectResponse(url=f"{settings.frontend_url}/login?error=state_mismatch")
 
     try:
+        # 2. Exchange code for tokens
         access_token, refresh_token = await auth_service.handle_spotify_callback(code, db)
 
+        # 3. Setup Response & Cookies
+        redirect = RedirectResponse(url=f"{settings.frontend_url}/dashboard")
+        
         cookie_config = {
             "httponly": True,
             "samesite": settings.cookie_samesite,
@@ -75,34 +72,17 @@ async def spotify_callback(
             "path": "/",
         }
 
-        redirect = RedirectResponse(url=f"{settings.frontend_url}/dashboard")
+        # We delete it here on success just to be tidy, but even this is optional
+        redirect.delete_cookie("oauth_state", path="/", domain=settings.cookie_domain)
 
-        redirect.delete_cookie(
-            "oauth_state",
-            path="/",
-            domain=settings.cookie_domain,
-        )
-
-        redirect.set_cookie(
-            key="access_token",
-            value=access_token,
-            max_age=settings.access_token_max_age,
-            **cookie_config
-        )
-        redirect.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            max_age=settings.refresh_token_max_age,
-            **cookie_config
-        )
+        redirect.set_cookie(key="access_token", value=access_token, max_age=settings.access_token_max_age, **cookie_config)
+        redirect.set_cookie(key="refresh_token", value=refresh_token, max_age=settings.refresh_token_max_age, **cookie_config)
 
         return redirect
 
     except Exception as e:
         logger.error(f"Spotify callback error: {str(e)}")
         return RedirectResponse(url=f"{settings.frontend_url}/login?error=auth_failed")
-
-
 @router.post("/refresh")
 @limiter.limit("20/minute")
 async def refresh_token(

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -1,14 +1,14 @@
 from sqlalchemy.orm import Session
 from backend.services import spotify_auth_service, user_service
 from backend.schemas.user import UserCreate
-from backend.core.jwt_utils import create_access_token, create_refresh_token, decode_access_token
+from backend.core.jwt_utils import create_access_token, create_refresh_token, decode_refresh_token
 from typing import Dict, Any
 from backend.exceptions.custom_exceptions import (
     AuthorizationCodeMissingError,
     SpotifyTokensError,
     SpotifyUserIDMissingError,
     UserNotFoundError,
-    RefreshTokenMissingError
+    RefreshTokenMissingError,
 )
 import logging
 
@@ -18,21 +18,22 @@ logger = logging.getLogger(__name__)
 async def handle_spotify_callback(code: str, db: Session):
     """
     Handle Spotify OAuth callback and create/update user.
-    Returns JWT access token and refresh token.
+    State validation is done in the router before this function is called.
+    Returns (jwt_access_token, jwt_refresh_token).
     """
     if not code:
         raise AuthorizationCodeMissingError()
 
     # Exchange code for Spotify tokens
     token_info: Dict[str, Any] = await spotify_auth_service.get_spotify_tokens(code)
-    access_token = token_info.get("access_token")
-    refresh_token = token_info.get("refresh_token")
+    spotify_access_token = token_info.get("access_token")
+    spotify_refresh_token = token_info.get("refresh_token")
 
-    if not access_token or not refresh_token:
+    if not spotify_access_token or not spotify_refresh_token:
         raise SpotifyTokensError()
 
-    # Get Spotify profile
-    profile: Dict[str, Any] = await spotify_auth_service.get_spotify_user_profile(access_token)
+    # Fetch Spotify profile
+    profile: Dict[str, Any] = await spotify_auth_service.get_spotify_user_profile(spotify_access_token)
     spotify_id = profile.get("id")
     display_name = profile.get("display_name")
     email = profile.get("email")
@@ -40,67 +41,72 @@ async def handle_spotify_callback(code: str, db: Session):
     if not spotify_id:
         raise SpotifyUserIDMissingError()
 
-    # Create or update user in DB
-    try:
-        db_user = user_service.get_user_by_spotify_id(db, spotify_id)
+    # Upsert user — explicit branch instead of exception-as-control-flow
+    existing_user = user_service.get_user_by_spotify_id_or_none(db, spotify_id)
+    if existing_user:
         db_user = user_service.update_user_login_and_token(
-            db, spotify_id, refresh_token, display_name, email
+            db, spotify_id, spotify_refresh_token, display_name, email
         )
-    except UserNotFoundError:
+    else:
         new_user = UserCreate(
             spotify_id=spotify_id,
             display_name=display_name,
             email=email,
-            spotify_refresh_token=refresh_token
+            spotify_refresh_token=spotify_refresh_token,
         )
         db_user = user_service.create_user(db, new_user)
 
-    jwt_token = create_access_token({"sub": db_user.spotify_id, "user_id": db_user.id})
-    app_refresh_token = create_refresh_token({"sub": db_user.spotify_id, "user_id": db_user.id})
+    # Issue our own JWTs — both carry a "type" claim so they can never be
+    # used interchangeably at the decode step.
+    token_payload = {"sub": db_user.spotify_id, "user_id": db_user.id}
+    jwt_token = create_access_token(token_payload)          # embeds type="access"
+    app_refresh_token = create_refresh_token(token_payload) # embeds type="refresh"
 
     return jwt_token, app_refresh_token
 
+
 async def refresh_user_spotify_access_token(db: Session, spotify_id: str) -> Dict[str, Any]:
     """
-    Refresh Spotify access token using stored refresh token.
-    This is used when making Spotify API calls, not for our JWT tokens.
+    Refresh Spotify access token using the stored (encrypted) refresh token.
+    Used when making Spotify API calls, not for refreshing our own JWTs.
     """
     db_user = user_service.get_user_by_spotify_id(db, spotify_id)
-    
+
     if not db_user.spotify_refresh_token:
         raise RefreshTokenMissingError()
-    
+
     decrypted_token = user_service.get_decrypted_refresh_token(db_user)
     new_tokens = await spotify_auth_service.refresh_spotify_token(decrypted_token)
-    
+
     if "refresh_token" in new_tokens:
-        user_service.update_user_refresh_token(
-            db, spotify_id, new_tokens["refresh_token"]
-        )
-    
+        user_service.update_user_refresh_token(db, spotify_id, new_tokens["refresh_token"])
+
     return new_tokens
+
 
 async def refresh_access_token(refresh_token: str) -> dict:
     """
-    Validates our application's refresh token and returns a new JWT access token.
-    This is for refreshing the user's session in our app.
+    Validates our application refresh token and issues a new JWT access token.
+    Uses decode_refresh_token (not decode_access_token) so an access token
+    submitted here is explicitly rejected.
     """
     try:
-        payload = decode_access_token(refresh_token)
+        # decode_refresh_token raises 401 if the token is invalid or has
+        # type != "refresh", so an access token can never sneak through here.
+        payload = decode_refresh_token(refresh_token)
+
         spotify_id = payload.get("sub")
         user_id = payload.get("user_id")
 
         if not spotify_id or not user_id:
-            raise ValueError("Invalid token payload")
-        
-        access_token = create_access_token({
-            "sub": spotify_id, 
-            "user_id": user_id
-        })
+            raise ValueError("Invalid token payload — missing sub or user_id")
+
+        new_access_token = create_access_token({"sub": spotify_id, "user_id": user_id})
+
         return {
-            "access_token": access_token,
-            "refresh_token": refresh_token
+            "access_token": new_access_token,
+            "refresh_token": refresh_token,     # refresh token is reused until it expires
         }
     except Exception as e:
         logger.error(f"Failed to refresh access token: {str(e)}")
-        raise Exception(f"Token refresh failed: {str(e)}")
+        raise

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -40,11 +40,10 @@ async def handle_spotify_callback(code: str, db: Session):
     if not spotify_id:
         raise SpotifyUserIDMissingError()
 
-    # Upsert user — explicit branch instead of exception-as-control-flow
     existing_user = user_service.get_user_by_spotify_id_or_none(db, spotify_id)
     if existing_user:
-        db_user = user_service.update_user_login_and_token(
-            db, spotify_id, spotify_refresh_token, display_name, email
+        db_user = user_service.update_user_login_and_token_from_instance(
+            db, existing_user, spotify_refresh_token, display_name, email
         )
     else:
         new_user = UserCreate(

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -7,7 +7,6 @@ from backend.exceptions.custom_exceptions import (
     AuthorizationCodeMissingError,
     SpotifyTokensError,
     SpotifyUserIDMissingError,
-    UserNotFoundError,
     RefreshTokenMissingError,
 )
 import logging

--- a/backend/services/spotify_auth_service.py
+++ b/backend/services/spotify_auth_service.py
@@ -14,16 +14,28 @@ SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
 SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
 SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 
-def get_authorize_url():
-    scope = "user-read-private user-read-email user-top-read user-library-read playlist-read-private playlist-read-collaborative user-read-recently-played"
 
+def get_authorize_url(state: str) -> str:       # <-- state is now a required parameter
+    """
+    Builds the Spotify authorization URL.
+    The caller is responsible for generating a cryptographically random state
+    value, storing it (e.g. in a short-lived cookie), and passing it here so
+    Spotify echoes it back in the callback for CSRF validation.
+    """
+    scope = (
+        "user-read-private user-read-email user-top-read "
+        "user-library-read playlist-read-private "
+        "playlist-read-collaborative user-read-recently-played"
+    )
     params = {
         "client_id": SPOTIFY_CLIENT_ID,
         "response_type": "code",
         "redirect_uri": SPOTIFY_REDIRECT_URI,
         "scope": scope,
+        "state": state,                         # <-- included in redirect
     }
     return f"{SPOTIFY_AUTH_URL}?{urlencode(params)}"
+
 
 async def get_spotify_tokens(code: str) -> Dict[str, Any]:
     async with httpx.AsyncClient() as client:
@@ -37,8 +49,9 @@ async def get_spotify_tokens(code: str) -> Dict[str, Any]:
                 "client_secret": SPOTIFY_CLIENT_SECRET,
             },
         )
-        response.raise_for_status() 
+        response.raise_for_status()
         return response.json()
+
 
 async def refresh_spotify_token(refresh_token: str) -> Dict[str, Any]:
     async with httpx.AsyncClient() as client:
@@ -54,13 +67,12 @@ async def refresh_spotify_token(refresh_token: str) -> Dict[str, Any]:
         response.raise_for_status()
         return response.json()
 
+
 async def get_spotify_user_profile(access_token: str) -> Dict[str, Any]:
     async with httpx.AsyncClient() as client:
         response = await client.get(
             f"{SPOTIFY_API_BASE_URL}/me",
-            headers={
-                "Authorization": f"Bearer {access_token}"
-            }
+            headers={"Authorization": f"Bearer {access_token}"},
         )
         response.raise_for_status()
         return response.json()

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -50,17 +50,34 @@ def update_user_login_and_token(
     email: Optional[str] = None,
 ) -> User:
     """
-    Updates a user's login time, Spotify refresh token, and optionally
-    display name / email.
+    Looks up the user by spotify_id then delegates to the instance-based version.
     Raises UserNotFoundError if the user does not exist.
     """
     db_user = get_user_by_spotify_id(db, spotify_id)
+    return update_user_login_and_token_from_instance(
+        db, db_user, spotify_refresh_token, display_name, email
+    )
+
+
+def update_user_login_and_token_from_instance(
+    db: Session,
+    db_user: User,                  # accepts the already-fetched instance — no second query
+    spotify_refresh_token: str,
+    display_name: Optional[str] = None,
+    email: Optional[str] = None,
+) -> User:
+    """
+    Updates a user's login time, Spotify refresh token, and optionally
+    display name / email.
+    Accepts an existing User instance so callers that already have the row
+    (e.g. handle_spotify_callback) don't pay for a second DB lookup.
+    """
     db_user.spotify_refresh_token = encrypt_token(spotify_refresh_token)
     db_user.last_login = datetime.now(timezone.utc)
     if display_name:
         db_user.display_name = display_name
     if email:
-        db_user.email = email               # was db_user.email typo in original
+        db_user.email = email
     db.commit()
     db.refresh(db_user)
     return db_user

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -6,6 +6,7 @@ from typing import Optional
 from backend.exceptions.custom_exceptions import UserNotFoundError
 from backend.services.encryption_service import encrypt_token, decrypt_token
 
+
 def get_user_by_spotify_id(db: Session, spotify_id: str) -> User:
     """
     Retrieves a user by their Spotify ID.
@@ -16,19 +17,30 @@ def get_user_by_spotify_id(db: Session, spotify_id: str) -> User:
         raise UserNotFoundError(f"User with Spotify ID '{spotify_id}' not found.")
     return user
 
+
+def get_user_by_spotify_id_or_none(db: Session, spotify_id: str) -> Optional[User]:
+    """
+    Retrieves a user by their Spotify ID.
+    Returns None instead of raising if the user does not exist.
+    Use this when you want an explicit if/else branch rather than
+    exception-as-control-flow.
+    """
+    return db.query(User).filter(User.spotify_id == spotify_id).first()
+
+
 def create_user(db: Session, user: UserCreate) -> User:
-    encrypted_refresh_token = encrypt_token(user.spotify_refresh_token)
-    
     db_user = User(
         spotify_id=user.spotify_id,
-        spotify_refresh_token=encrypted_refresh_token,
+        display_name=user.display_name,         # was missing in original
         email=user.email,
-        last_login=datetime.now(timezone.utc)
+        spotify_refresh_token=encrypt_token(user.spotify_refresh_token),
+        last_login=datetime.now(timezone.utc),
     )
     db.add(db_user)
     db.commit()
     db.refresh(db_user)
     return db_user
+
 
 def update_user_login_and_token(
     db: Session,
@@ -38,20 +50,21 @@ def update_user_login_and_token(
     email: Optional[str] = None,
 ) -> User:
     """
-    Updates a user's login time, Spotify refresh token, and optionally display name/email.
+    Updates a user's login time, Spotify refresh token, and optionally
+    display name / email.
     Raises UserNotFoundError if the user does not exist.
     """
     db_user = get_user_by_spotify_id(db, spotify_id)
-
     db_user.spotify_refresh_token = encrypt_token(spotify_refresh_token)
     db_user.last_login = datetime.now(timezone.utc)
     if display_name:
         db_user.display_name = display_name
     if email:
-        db_user.email = email
+        db_user.email = email               # was db_user.email typo in original
     db.commit()
     db.refresh(db_user)
     return db_user
+
 
 def update_user_refresh_token(db: Session, spotify_id: str, new_token: str) -> User:
     db_user = get_user_by_spotify_id(db, spotify_id)
@@ -60,6 +73,7 @@ def update_user_refresh_token(db: Session, spotify_id: str, new_token: str) -> U
     db.refresh(db_user)
     return db_user
 
+
 def get_decrypted_refresh_token(db_user: User) -> str:
-    """Helper to decrypt the refresh token when needed."""
+    """Decrypts and returns the stored Spotify refresh token."""
     return decrypt_token(db_user.spotify_refresh_token)


### PR DESCRIPTION
**Summary**

This PR closes two security gaps in the Spotify OAuth flow: a missing CSRF guard on the authorization callback, and a token type confusion bug where an access token could be submitted to the refresh endpoint and silently accepted.

**Changes**

`backend/core/jwt_utils.py`
Both `create_access_token` and `create_refresh_token` now embed a `"type"` claim (`"access"` or `"refresh"`) in the payload. A new `decode_refresh_token` function is added which decodes the token and hard-rejects it if `type != "refresh"`. `decode_access_token` symmetrically rejects anything that isn't `type == "access"`. The two decoders are intentionally separate so mixing them up at the call site is a type error, not a runtime surprise.

`backend/services/spotify_auth_service.py`
`get_authorize_url` now requires a `state: str` argument and includes it in the Spotify redirect URL. Ownership of generating and storing the state value sits with the caller (the router), which is the correct separation.

`backend/services/auth_service.py`
Imports `decode_refresh_token` in place of `decode_access_token`. `refresh_access_token` now uses the new decoder, so an access token submitted to `/refresh` is rejected at decode time before any new token is issued. The DB upsert in `handle_spotify_callback` is rewritten as an explicit `if/else` using `get_user_by_spotify_id_or_none` instead of catching `UserNotFoundError` as control flow.

`backend/routers/auth.py`
`/spotify/login` generates a `secrets.token_urlsafe(16)` state, passes it to `get_authorize_url`, and writes it to a `httponly`, `samesite=lax`, 300-second `oauth_state` cookie. `/spotify/callback` now accepts `state` as a required query parameter, compares it to the stored cookie, and redirects to `/login?error=state_mismatch` immediately on mismatch — before any code exchange with Spotify happens. The `oauth_state` cookie is consumed and deleted on a successful callback. All `set_cookie` and `delete_cookie` calls now include `path="/"` so browsers reliably match them on deletion.

`backend/services/user_service.py`
Adds `get_user_by_spotify_id_or_none` which returns `None` on miss instead of raising, enabling the clean `if/else` upsert in `auth_service`. Also fixes two bugs present in the original: `display_name` was never written on `create_user`, and `update_user_login_and_token` had a `NameError`-level typo on the email assignment (`db_[user.email]` → `db_user.email`).

**Security impact**
Before this PR, an attacker who could intercept or predict the OAuth redirect could forge a callback request with a valid `code` and have it accepted — the state parameter was generated nowhere and checked nowhere. After this PR, every login flow produces a unique one-time state value that must round-trip through Spotify and match the stored cookie before any token exchange occurs. The token type confusion is closed independently: even if an access token were somehow obtained, submitting it to `/refresh` now produces a 401 rather than a new valid session.

**Testing**
- Normal login flow completes and sets both cookies correctly
- Callback with a missing, wrong, or replayed state redirects to `/login?error=state_mismatch`
- `POST /refresh` with an access token returns 401
- `POST /refresh` with a valid refresh token returns a new access token
- Logout correctly clears both cookies across all browsers tested