### PR TITLE
Bug/correct auth flow

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -51,8 +51,8 @@ All endpoints are rate-limited to prevent abuse. Limits vary by endpoint.
     frontend_url: str = Field(default="http://127.0.0.1:5173", alias="FRONTEND_URL")
     cookie_domain: Optional[str] = Field(default=None, alias="COOKIE_DOMAIN")
 
-    # Cookie Expiration Times (in seconds)
-    oauth_state_max_age: int = Field(default=300, alias="OAUTH_STATE_MAX_AGE")  # 5 minutes
+    # Cookie Expiration Times
+    oauth_state_max_age: int = Field(default=300, alias="OAUTH_STATE_MAX_AGE")
 
     @property
     def access_token_max_age(self) -> int:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -78,6 +78,19 @@ All endpoints are rate-limited to prevent abuse. Limits vary by endpoint.
     # Spotify API
     spotify_client_id: Optional[str] = Field(default=None, alias="SPOTIFY_CLIENT_ID")
     spotify_client_secret: Optional[str] = Field(default=None, alias="SPOTIFY_CLIENT_SECRET")
+    spotify_redirect_uri: str = Field(..., alias="SPOTIFY_REDIRECT_URI")
+    
+    # Spotify API Endpoints (Constants)
+    spotify_auth_url: str = "https://accounts.spotify.com/authorize"
+    spotify_token_url: str = "https://accounts.spotify.com/api/token"
+    spotify_api_base_url: str = "https://api.spotify.com/v1"
+    
+    # Spotify Scopes
+    spotify_scopes: str = (
+        "user-read-private user-read-email user-top-read "
+        "user-library-read playlist-read-private "
+        "playlist-read-collaborative user-read-recently-played"
+    )
     
     # Computed properties
     @property

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -1,31 +1,40 @@
 from fastapi import Depends, HTTPException, status, Request
 from sqlalchemy.orm import Session
 from backend.database.connection import get_db
+from backend.database.redis import get_redis, JWTDenylist
 from backend.core.jwt_utils import decode_access_token
 from backend.services import user_service
 from backend.models.user import User
 from backend.exceptions.custom_exceptions import UserNotFoundError
+import logging
 
-def get_current_user(
-    request: Request, 
-    db: Session = Depends(get_db)
+logger = logging.getLogger(__name__)
+
+
+async def get_current_user(
+    request: Request,
+    db: Session = Depends(get_db),
+    redis_client=Depends(get_redis),
 ) -> User:
     """
-    Hybrid dependency: checks for JWT in the Authorization Header first,
-    then falls back to the 'access_token' Cookie.
+    Hybrid dependency: checks for JWT in the Authorization header first,
+    then falls back to the 'access_token' cookie.
+
+    After decoding, the token's jti is checked against the Redis denylist
+    so that logged-out tokens are rejected even while still technically
+    unexpired. Redis unavailability is fail-open (logged but not fatal).
     """
     token = None
 
-    # 1. Try to extract token from Authorization Header (Postman/Mobile)
+    # 1. Try Authorization header (API clients / Postman)
     auth_header = request.headers.get("Authorization")
     if auth_header and auth_header.startswith("Bearer "):
         token = auth_header.split(" ")[1]
-    
-    # 2. If no header, try to extract from Cookies (Browser)
+
+    # 2. Fall back to cookie (browser)
     if not token:
         token = request.cookies.get("access_token")
 
-    # If still no token, the user is not logged in
     if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -33,30 +42,41 @@ def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # 3. Decode — raises 401 on invalid signature, expiry, or wrong type
     try:
-        # 3. Decode the token
         payload = decode_access_token(token)
-        spotify_id: str = payload.get("sub")
-        
-        if spotify_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token payload.",
-            )
-        
-        # 4. Fetch the user from the database
-        user = user_service.get_user_by_spotify_id(db, spotify_id)
-        return user
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token validation failed.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
+    spotify_id: str = payload.get("sub")
+    jti: str = payload.get("jti")
+
+    if not spotify_id or not jti:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload.",
+        )
+
+    # 4. Denylist check — fail-open if Redis is down (JWTDenylist handles logging)
+    denylist = JWTDenylist(redis_client)
+    if await denylist.is_denied(jti):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has been revoked.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # 5. Load user from DB
+    try:
+        return user_service.get_user_by_spotify_id(db, spotify_id)
     except UserNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found.",
         )
-    except Exception as e:
-        # Catch expired tokens, signature errors, etc.
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Token validation failed: {str(e)}",
-        )
-    

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, HTTPException, status, Request
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
 from backend.database.connection import get_db
 from backend.database.redis import get_redis, JWTDenylist
 from backend.core.jwt_utils import decode_access_token
@@ -26,12 +27,10 @@ async def get_current_user(
     """
     token = None
 
-    # 1. Try Authorization header (API clients / Postman)
     auth_header = request.headers.get("Authorization")
     if auth_header and auth_header.startswith("Bearer "):
         token = auth_header.split(" ")[1]
 
-    # 2. Fall back to cookie (browser)
     if not token:
         token = request.cookies.get("access_token")
 
@@ -42,41 +41,51 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # 3. Decode — raises 401 on invalid signature, expiry, or wrong type
     try:
         payload = decode_access_token(token)
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception:
+        logger.exception("Unexpected error decoding access token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token validation failed.",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    spotify_id: str = payload.get("sub")
-    jti: str = payload.get("jti")
+    spotify_id: str | None = payload.get("sub")
+    jti: str | None = payload.get("jti")
 
-    if not spotify_id or not jti:
+    if not spotify_id:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token payload.",
         )
 
-    # 4. Denylist check — fail-open if Redis is down (JWTDenylist handles logging)
     denylist = JWTDenylist(redis_client)
-    if await denylist.is_denied(jti):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token has been revoked.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+    if jti:
+        if await denylist.is_denied(jti):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token has been revoked.",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    else:
+        logger.debug("Token missing jti claim — denylist check skipped (pre-rollout token)")
 
-    # 5. Load user from DB
+    # Cache payload for downstream handlers (e.g. /logout avoids a second decode)
+    request.state.token_payload = payload
+
     try:
         return user_service.get_user_by_spotify_id(db, spotify_id)
     except UserNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found.",
+        )
+    except SQLAlchemyError:
+        logger.exception("Database error in get_current_user for sub=%s", spotify_id)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service temporarily unavailable.",
         )

--- a/backend/core/jwt_utils.py
+++ b/backend/core/jwt_utils.py
@@ -14,7 +14,7 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     to_encode.update({
         "exp": expire,
         "iat": datetime.now(timezone.utc),
-        "type": "access",       # <-- type claim added
+        "type": "access",
     })
     return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 
@@ -28,7 +28,7 @@ def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) 
     to_encode.update({
         "exp": expire,
         "iat": datetime.now(timezone.utc),
-        "type": "refresh",      # <-- type claim added
+        "type": "refresh",
     })
     return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 

--- a/backend/core/jwt_utils.py
+++ b/backend/core/jwt_utils.py
@@ -3,40 +3,41 @@ from typing import Optional
 from jose import JWTError, jwt
 from fastapi import HTTPException, status
 from backend.core.config import settings
+import uuid
 
 
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+def _base_claims(data: dict, expire: datetime, token_type: str) -> dict:
+    """Build common claims shared by both token types."""
     to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
-    else:
-        expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
     to_encode.update({
         "exp": expire,
         "iat": datetime.now(timezone.utc),
-        "type": "access",
+        "type": token_type,
+        "jti": str(uuid.uuid4()),   # unique ID — used as the denylist key
     })
+    return to_encode
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
+    )
+    to_encode = _base_claims(data, expire, "access")
     return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 
 
 def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
-    to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
-    else:
-        expire = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
-    to_encode.update({
-        "exp": expire,
-        "iat": datetime.now(timezone.utc),
-        "type": "refresh",
-    })
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(days=settings.refresh_token_expire_days)
+    )
+    to_encode = _base_claims(data, expire, "refresh")
     return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 
 
-def decode_access_token(token: str) -> dict:
+def _decode_and_validate(token: str, expected_type: str) -> dict:
     """
-    Decodes and validates an access token.
-    Raises 401 if the token is invalid or is not an access token.
+    Shared decode logic. Raises 401 on any failure so the two public
+    functions can never be used interchangeably.
     """
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
@@ -46,13 +47,21 @@ def decode_access_token(token: str) -> dict:
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    if payload.get("type") != "access":
+    if payload.get("type") != expected_type:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token type",
             headers={"WWW-Authenticate": "Bearer"},
         )
     return payload
+
+
+def decode_access_token(token: str) -> dict:
+    """
+    Decodes and validates an access token.
+    Raises 401 if the token is invalid or is not an access token.
+    """
+    return _decode_and_validate(token, "access")
 
 
 def decode_refresh_token(token: str) -> dict:
@@ -62,18 +71,4 @@ def decode_refresh_token(token: str) -> dict:
     This is intentionally separate from decode_access_token so the two
     token types can never be used interchangeably.
     """
-    try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
-    except JWTError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    if payload.get("type") != "refresh":
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token type",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    return payload
+    return _decode_and_validate(token, "refresh")

--- a/backend/database/redis.py
+++ b/backend/database/redis.py
@@ -77,6 +77,8 @@ async def get_redis():
     except Exception as e:
         redis_breaker.record_failure()
         logger.warning(f"Redis unavailable: {e}")
+        if client is not None:
+            await client.aclose()
         yield None
         return
     
@@ -175,7 +177,10 @@ class RedisTokenCache:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
+import time
 
+_last_deny_warn: float = 0.0
+_DENY_WARN_INTERVAL = 60.0
 class JWTDenylist:
     """
     Stores revoked JWT IDs (jti claims) in Redis with a TTL matching the
@@ -208,7 +213,7 @@ class JWTDenylist:
         Returns True on success, False if Redis is unavailable.
         """
         if not self.redis:
-            logger.warning("JWTDenylist.add: Redis unavailable — token jti=%s not denylisted", jti)
+            logger.warning("JWTDenylist.add: Redis unavailable — jti=%.8s not denylisted", jti)
             return False
         try:
             await self.redis.set(self._key(jti), "1", ex=max(1, ttl_seconds))
@@ -222,11 +227,23 @@ class JWTDenylist:
         Returns True if the jti is on the denylist.
         Returns False (fail-open) if Redis is unavailable — logs the bypass.
         """
+        global _last_deny_warn
+
         if not self.redis:
-            logger.warning("JWTDenylist.is_denied: Redis unavailable — fail-open for jti=%s", jti)
+            # Fix #2: throttle — log at most once per minute during outage
+            now = time.monotonic()
+            if now - _last_deny_warn >= _DENY_WARN_INTERVAL:
+                logger.warning(
+                    "JWTDenylist.is_denied: Redis unavailable — failing open. "
+                    "Revoked tokens may be accepted until Redis recovers."
+                )
+                _last_deny_warn = now
             return False
         try:
             return bool(await self.redis.exists(self._key(jti)))
         except (ConnectionError, TimeoutError) as e:
-            logger.warning("JWTDenylist.is_denied failed (Redis error) — fail-open: %s", e)
+            now = time.monotonic()
+            if now - _last_deny_warn >= _DENY_WARN_INTERVAL:
+                logger.warning("JWTDenylist.is_denied failed (Redis error) — fail-open: %s", e)
+                _last_deny_warn = now
             return False

--- a/backend/database/redis.py
+++ b/backend/database/redis.py
@@ -177,8 +177,6 @@ class RedisTokenCache:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
-import time
-
 _last_deny_warn: float = 0.0
 _DENY_WARN_INTERVAL = 60.0
 class JWTDenylist:

--- a/backend/database/redis.py
+++ b/backend/database/redis.py
@@ -67,19 +67,23 @@ async def get_redis():
     if not redis_breaker.is_available():
         yield None
         return
+
+    client = None
     try:
         pool = _get_pool()
         client = redis.Redis(connection_pool=pool)
         await client.ping()
         redis_breaker.record_success()
-        try:
-            yield client
-        finally:
-            await client.aclose()
     except Exception as e:
         redis_breaker.record_failure()
         logger.warning(f"Redis unavailable: {e}")
         yield None
+        return
+    
+    try:
+        yield client
+    finally:
+        await client.aclose()
 
 async def ping_redis() -> bool:
     client = None

--- a/backend/database/redis.py
+++ b/backend/database/redis.py
@@ -96,6 +96,7 @@ async def ping_redis() -> bool:
         if client is not None:
             await client.aclose()
 
+
 class RedisTokenCache:
     TOKEN_PREFIX = "spotify:token:"
     LOCK_PREFIX = "spotify:lock:refresh:"
@@ -169,3 +170,59 @@ class RedisTokenCache:
             return stats
         except Exception as e:
             return {"status": "error", "error": str(e)}
+
+
+class JWTDenylist:
+    """
+    Stores revoked JWT IDs (jti claims) in Redis with a TTL matching the
+    token's remaining lifetime.
+
+    Keys:   jwt:deny:{jti}
+    Value:  "1" (presence is all that matters)
+    TTL:    set to the token's remaining seconds so Redis self-cleans —
+            no background job needed.
+
+    Fail-open policy: if Redis is unavailable, is_denied() returns False
+    so a Redis outage does not lock all users out. Log the bypass so it
+    is visible in monitoring.
+    """
+
+    DENY_PREFIX = "jwt:deny:"
+
+    def __init__(self, redis_client: redis.Redis | None):
+        self.redis = redis_client
+
+    def _key(self, jti: str) -> str:
+        return f"{self.DENY_PREFIX}{jti}"
+
+    async def add(self, jti: str, ttl_seconds: int) -> bool:
+        """
+        Deny a jti for ttl_seconds.
+        ttl_seconds should be the token's remaining lifetime so the key
+        self-expires exactly when the token would have anyway.
+        Clamps to 1 second minimum so we never set a key with ex=0.
+        Returns True on success, False if Redis is unavailable.
+        """
+        if not self.redis:
+            logger.warning("JWTDenylist.add: Redis unavailable — token jti=%s not denylisted", jti)
+            return False
+        try:
+            await self.redis.set(self._key(jti), "1", ex=max(1, ttl_seconds))
+            return True
+        except (ConnectionError, TimeoutError) as e:
+            logger.warning("JWTDenylist.add failed (Redis error): %s", e)
+            return False
+
+    async def is_denied(self, jti: str) -> bool:
+        """
+        Returns True if the jti is on the denylist.
+        Returns False (fail-open) if Redis is unavailable — logs the bypass.
+        """
+        if not self.redis:
+            logger.warning("JWTDenylist.is_denied: Redis unavailable — fail-open for jti=%s", jti)
+            return False
+        try:
+            return bool(await self.redis.exists(self._key(jti)))
+        except (ConnectionError, TimeoutError) as e:
+            logger.warning("JWTDenylist.is_denied failed (Redis error) — fail-open: %s", e)
+            return False

--- a/backend/database/redis.py
+++ b/backend/database/redis.py
@@ -176,7 +176,10 @@ class RedisTokenCache:
             return stats
         except Exception as e:
             return {"status": "error", "error": str(e)}
+        
 
+# _last_deny_warn is per-process. Under multi-worker deployments each worker
+# throttles independently — total log volume scales with worker count.
 _last_deny_warn: float = 0.0
 _DENY_WARN_INTERVAL = 60.0
 class JWTDenylist:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -133,17 +133,13 @@ async def refresh_token(
         )
 
     old_refresh_jti = new_tokens["old_refresh_jti"]
+    old_refresh_exp = new_tokens["old_refresh_exp"]
 
-    # Denylist the consumed refresh token
+    # Denylist the consumed refresh token — exp comes from the service so
+    # there is no second decode here and no fallback failure path needed.
     denylist = JWTDenylist(redis_client)
     if old_refresh_jti:
-        try:
-            old_payload = decode_refresh_token(refresh_token_value)
-            exp = old_payload.get("exp", 0)
-            remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
-        except Exception:
-            remaining_ttl = settings.refresh_token_expire_days * 86400
-
+        remaining_ttl = max(1, int(old_refresh_exp - datetime.now(timezone.utc).timestamp()))
         await denylist.add(old_refresh_jti, remaining_ttl)
 
     cookie_config = {

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -12,7 +12,6 @@ from backend.database.redis import get_redis, RedisTokenCache, JWTDenylist
 from backend.core.rate_limiter import limiter
 from backend.core.config import settings
 from backend.core.dependencies import get_current_user
-from backend.core.jwt_utils import decode_access_token
 from backend.models.user import User
 from backend.exceptions.custom_exceptions import SpotifyTokensError, SpotifyUserIDMissingError
 from backend.core.jwt_utils import decode_refresh_token

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -16,6 +16,7 @@ from backend.core.dependencies import get_current_user
 from backend.core.jwt_utils import decode_access_token
 from backend.models.user import User
 from backend.exceptions.custom_exceptions import SpotifyTokensError, SpotifyUserIDMissingError
+from backend.core.jwt_utils import decode_refresh_token
 
 logger = logging.getLogger(__name__)
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -139,7 +139,6 @@ async def refresh_token(
     if old_refresh_jti:
         # Remaining TTL of the old token — decode it to get exp
         try:
-            from backend.core.jwt_utils import decode_refresh_token
             old_payload = decode_refresh_token(refresh_token_value)
             exp = old_payload.get("exp", 0)
             remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,5 +1,6 @@
 import secrets
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Response, Request, HTTPException, status
@@ -8,15 +9,18 @@ from sqlalchemy.orm import Session
 
 from backend.services import auth_service, spotify_auth_service
 from backend.database.connection import get_db
-from backend.database.redis import get_redis, RedisTokenCache
+from backend.database.redis import get_redis, RedisTokenCache, JWTDenylist
 from backend.core.rate_limiter import limiter
 from backend.core.config import settings
 from backend.core.dependencies import get_current_user
+from backend.core.jwt_utils import decode_access_token, decode_refresh_token
 from backend.models.user import User
+from backend.exceptions.custom_exceptions import SpotifyTokensError, SpotifyUserIDMissingError
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/auth", tags=["Authentication"])
+
 
 @router.get("/spotify/login")
 @limiter.limit("10/minute")
@@ -51,50 +55,57 @@ async def spotify_callback(
     state: str,
     db: Session = Depends(get_db),
 ):
-    # 1. CSRF Check: Compare incoming state to the one in our cookie
     stored_state = request.cookies.get("oauth_state")
-    if not secrets.compare_digest(state, stored_state or ""):
-        logger.warning("OAuth state mismatch")
+    if not stored_state:
+        logger.warning("OAuth state cookie missing from callback request")
+        return RedirectResponse(url=f"{settings.frontend_url}/login?error=state_missing")
+    if not secrets.compare_digest(state, stored_state):
+        logger.warning("OAuth state mismatch — possible CSRF attempt")
         return RedirectResponse(url=f"{settings.frontend_url}/login?error=state_mismatch")
 
     try:
-        # 2. Exchange code for tokens
         access_token, refresh_token = await auth_service.handle_spotify_callback(code, db)
-
-        # 3. Setup Response & Cookies
-        redirect = RedirectResponse(url=f"{settings.frontend_url}/dashboard")
-        
-        cookie_config = {
-            "httponly": True,
-            "samesite": settings.cookie_samesite,
-            "secure": settings.cookie_secure,
-            "domain": settings.cookie_domain,
-            "path": "/",
-        }
-
-        # We delete it here on success just to be tidy, but even this is optional
-        redirect.delete_cookie("oauth_state", path="/", domain=settings.cookie_domain)
-
-        redirect.set_cookie(key="access_token", value=access_token, max_age=settings.access_token_max_age, **cookie_config)
-        redirect.set_cookie(key="refresh_token", value=refresh_token, max_age=settings.refresh_token_max_age, **cookie_config)
-
-        return redirect
-
+    except (SpotifyTokensError, SpotifyUserIDMissingError) as e:
+        # Spotify rejected the code or returned an incomplete profile — user-facing
+        logger.warning(f"Spotify auth rejected: {str(e)}")
+        return RedirectResponse(url=f"{settings.frontend_url}/login?error=spotify_auth_failed")
     except Exception as e:
-        logger.error(f"Spotify callback error: {str(e)}")
-        return RedirectResponse(url=f"{settings.frontend_url}/login?error=auth_failed")
+        # DB down, encryption error, etc. — server fault
+        logger.error(f"Internal error during Spotify callback: {str(e)}", exc_info=True)
+        return RedirectResponse(url=f"{settings.frontend_url}/login?error=server_error")
+
+    redirect = RedirectResponse(url=f"{settings.frontend_url}/dashboard")
+
+    cookie_config = {
+        "httponly": True,
+        "samesite": settings.cookie_samesite,
+        "secure": settings.cookie_secure,
+        "domain": settings.cookie_domain,
+        "path": "/",
+    }
+
+    redirect.delete_cookie("oauth_state", path="/", domain=settings.cookie_domain)
+    redirect.set_cookie(key="access_token", value=access_token, max_age=settings.access_token_max_age, **cookie_config)
+    redirect.set_cookie(key="refresh_token", value=refresh_token, max_age=settings.refresh_token_max_age, **cookie_config)
+
+    return redirect
+
+
 @router.post("/refresh")
 @limiter.limit("20/minute")
 async def refresh_token(
     request: Request,
     response: Response,
     db: Session = Depends(get_db),
+    redis_client=Depends(get_redis),
 ):
     """
-    Refresh the access token using the refresh token from cookie or header.
-    Returns a new access token and optionally sets it in cookies.
+    Validates the refresh token, issues a new access token, and rotates
+    the refresh token. The consumed refresh token's jti is denylisted so
+    it cannot be reused even while technically unexpired.
     """
     refresh_token_value = None
+    from_cookie = False
 
     auth_header = request.headers.get("Authorization")
     if auth_header and auth_header.startswith("Bearer "):
@@ -102,6 +113,8 @@ async def refresh_token(
 
     if not refresh_token_value:
         refresh_token_value = request.cookies.get("refresh_token")
+        if refresh_token_value:
+            from_cookie = True
 
     if not refresh_token_value:
         raise HTTPException(
@@ -111,32 +124,62 @@ async def refresh_token(
 
     try:
         new_tokens = await auth_service.refresh_access_token(refresh_token_value)
-
-        if request.cookies.get("refresh_token"):
-            response.set_cookie(
-                key="access_token",
-                value=new_tokens["access_token"],
-                max_age=settings.access_token_max_age,
-                httponly=True,
-                samesite=settings.cookie_samesite,
-                secure=settings.cookie_secure,
-                domain=settings.cookie_domain,
-                path="/",
-            )
-
-        logger.info("Access token refreshed successfully")
-        return {
-            "message": "Token refreshed successfully",
-            "access_token": new_tokens["access_token"],
-            "token_type": "bearer",
-        }
-
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Token refresh error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
+
+    old_refresh_jti = new_tokens["old_refresh_jti"]
+
+    # Denylist the consumed refresh token
+    denylist = JWTDenylist(redis_client)
+    if old_refresh_jti:
+        # Remaining TTL of the old token — decode it to get exp
+        try:
+            from backend.core.jwt_utils import decode_refresh_token
+            old_payload = decode_refresh_token(refresh_token_value)
+            exp = old_payload.get("exp", 0)
+            remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
+        except Exception:
+            # If we can't decode it here something is very wrong; use a safe fallback
+            remaining_ttl = settings.refresh_token_expire_days * 86400
+
+        await denylist.add(old_refresh_jti, remaining_ttl)
+
+    cookie_config = {
+        "httponly": True,
+        "samesite": settings.cookie_samesite,
+        "secure": settings.cookie_secure,
+        "domain": settings.cookie_domain,
+        "path": "/",
+    }
+
+    if from_cookie:
+        response.set_cookie(
+            key="access_token",
+            value=new_tokens["access_token"],
+            max_age=settings.access_token_max_age,
+            **cookie_config,
+        )
+        # Rotate the refresh token cookie
+        response.set_cookie(
+            key="refresh_token",
+            value=new_tokens["refresh_token"],
+            max_age=settings.refresh_token_max_age,
+            **cookie_config,
+        )
+
+    logger.info("Access and refresh tokens rotated successfully")
+    return {
+        "message": "Token refreshed successfully",
+        "access_token": new_tokens["access_token"],
+        "refresh_token": new_tokens["refresh_token"],
+        "token_type": "bearer",
+    }
 
 
 @router.post("/logout")
@@ -147,17 +190,58 @@ async def logout(
     current_user: User = Depends(get_current_user),
     redis_client=Depends(get_redis),
 ):
+    """
+    Logs the user out by:
+    1. Denylisting the current access token jti so it is rejected immediately.
+    2. Denylisting the current refresh token jti so it cannot be rotated into
+       a new access token.
+    3. Clearing the Spotify token cache entry.
+    4. Deleting the auth cookies.
+    """
+    denylist = JWTDenylist(redis_client)
+
+    # Denylist the access token
+    access_token_value = request.cookies.get("access_token")
+    auth_header = request.headers.get("Authorization")
+    if not access_token_value and auth_header and auth_header.startswith("Bearer "):
+        access_token_value = auth_header.split(" ")[1]
+
+    if access_token_value:
+        try:
+            payload = decode_access_token(access_token_value)
+            jti = payload.get("jti")
+            exp = payload.get("exp", 0)
+            if jti:
+                remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
+                await denylist.add(jti, remaining_ttl)
+                logger.info(f"Access token jti={jti} denylisted for user {current_user.spotify_id}")
+        except Exception as e:
+            logger.warning(f"Could not denylist access token on logout: {e}")
+
+    # Denylist the refresh token
+    refresh_token_value = request.cookies.get("refresh_token")
+    if refresh_token_value:
+        try:
+            from backend.core.jwt_utils import decode_refresh_token
+            payload = decode_refresh_token(refresh_token_value)
+            jti = payload.get("jti")
+            exp = payload.get("exp", 0)
+            if jti:
+                remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
+                await denylist.add(jti, remaining_ttl)
+                logger.info(f"Refresh token jti={jti} denylisted for user {current_user.spotify_id}")
+        except Exception as e:
+            logger.warning(f"Could not denylist refresh token on logout: {e}")
+
+    # Clear Spotify token cache
     try:
         if redis_client:
             cache = RedisTokenCache(redis_client)
             await cache.invalidate_token(current_user.spotify_id)
-            logger.info(f"User {current_user.spotify_id} logged out (cache cleared)")
-        else:
-            logger.info(f"User {current_user.spotify_id} logged out (cache bypass — Redis down)")
     except Exception as e:
         logger.error(f"Logout cache error (non-fatal): {str(e)}")
 
-    response.delete_cookie("access_token",  path="/", domain=settings.cookie_domain)
+    response.delete_cookie("access_token", path="/", domain=settings.cookie_domain)
     response.delete_cookie("refresh_token", path="/", domain=settings.cookie_domain)
 
     return {"message": "Logged out successfully"}

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -13,7 +13,7 @@ from backend.database.redis import get_redis, RedisTokenCache, JWTDenylist
 from backend.core.rate_limiter import limiter
 from backend.core.config import settings
 from backend.core.dependencies import get_current_user
-from backend.core.jwt_utils import decode_access_token, decode_refresh_token
+from backend.core.jwt_utils import decode_access_token
 from backend.models.user import User
 from backend.exceptions.custom_exceptions import SpotifyTokensError, SpotifyUserIDMissingError
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,7 +1,6 @@
 import secrets
 import logging
 from datetime import datetime, timezone
-from typing import Optional
 
 from fastapi import APIRouter, Depends, Response, Request, HTTPException, status
 from fastapi.responses import RedirectResponse, JSONResponse
@@ -25,7 +24,7 @@ router = APIRouter(prefix="/public/auth", tags=["Authentication"])
 
 @router.get("/spotify/login")
 @limiter.limit("10/minute")
-async def spotify_login(request: Request):
+async def spotify_login():
     """
     Initiate Spotify OAuth flow.
     Generates a cryptographically random state value, stores it in a
@@ -138,13 +137,11 @@ async def refresh_token(
     # Denylist the consumed refresh token
     denylist = JWTDenylist(redis_client)
     if old_refresh_jti:
-        # Remaining TTL of the old token — decode it to get exp
         try:
             old_payload = decode_refresh_token(refresh_token_value)
             exp = old_payload.get("exp", 0)
             remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
         except Exception:
-            # If we can't decode it here something is very wrong; use a safe fallback
             remaining_ttl = settings.refresh_token_expire_days * 86400
 
         await denylist.add(old_refresh_jti, remaining_ttl)
@@ -164,7 +161,6 @@ async def refresh_token(
             max_age=settings.access_token_max_age,
             **cookie_config,
         )
-        # Rotate the refresh token cookie
         response.set_cookie(
             key="refresh_token",
             value=new_tokens["refresh_token"],
@@ -172,13 +168,16 @@ async def refresh_token(
             **cookie_config,
         )
 
-    logger.info("Access and refresh tokens rotated successfully")
-    return {
+    logger.info("Tokens rotated successfully")
+    response_body: dict = {
         "message": "Token refreshed successfully",
         "access_token": new_tokens["access_token"],
-        "refresh_token": new_tokens["refresh_token"],
         "token_type": "bearer",
     }
+    if not from_cookie:
+        response_body["refresh_token"] = new_tokens["refresh_token"]
+
+    return response_body
 
 
 @router.post("/logout")
@@ -199,25 +198,25 @@ async def logout(
     """
     denylist = JWTDenylist(redis_client)
 
-    # Denylist the access token
-    access_token_value = request.cookies.get("access_token")
-    auth_header = request.headers.get("Authorization")
-    if not access_token_value and auth_header and auth_header.startswith("Bearer "):
-        access_token_value = auth_header.split(" ")[1]
+    # Denylist the access token — reuse the payload already decoded by
+    # get_current_user (stored on request.state) to avoid a second decode.
+    access_payload = getattr(request.state, "token_payload", None)
+    if access_payload:
+        jti = access_payload.get("jti")
+        exp = access_payload.get("exp", 0)
+        if jti:
+            remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
+            await denylist.add(jti, remaining_ttl)
+            # truncate jti in logs — full UUID can correlate sessions;
+            # first 8 chars is enough for debugging.
+            logger.info(
+                "Access token denylisted for user %s (jti=%.8s…)",
+                current_user.spotify_id,
+                jti,
+            )
 
-    if access_token_value:
-        try:
-            payload = decode_access_token(access_token_value)
-            jti = payload.get("jti")
-            exp = payload.get("exp", 0)
-            if jti:
-                remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
-                await denylist.add(jti, remaining_ttl)
-                logger.info(f"Access token jti={jti} denylisted for user {current_user.spotify_id}")
-        except Exception as e:
-            logger.warning(f"Could not denylist access token on logout: {e}")
-
-    # Denylist the refresh token
+    # Denylist the refresh token — still needs a decode since get_current_user
+    # only handles the access token.
     refresh_token_value = request.cookies.get("refresh_token")
     if refresh_token_value:
         try:
@@ -227,9 +226,13 @@ async def logout(
             if jti:
                 remaining_ttl = max(1, int(exp - datetime.now(timezone.utc).timestamp()))
                 await denylist.add(jti, remaining_ttl)
-                logger.info(f"Refresh token jti={jti} denylisted for user {current_user.spotify_id}")
+                logger.info(
+                    "Refresh token denylisted for user %s (jti=%.8s…)",
+                    current_user.spotify_id,
+                    jti,
+                )
         except Exception as e:
-            logger.warning(f"Could not denylist refresh token on logout: {e}")
+            logger.warning("Could not denylist refresh token on logout: %s", e)
 
     # Clear Spotify token cache
     try:
@@ -237,7 +240,7 @@ async def logout(
             cache = RedisTokenCache(redis_client)
             await cache.invalidate_token(current_user.spotify_id)
     except Exception as e:
-        logger.error(f"Logout cache error (non-fatal): {str(e)}")
+        logger.error("Logout cache error (non-fatal): %s", e)
 
     response.delete_cookie("access_token", path="/", domain=settings.cookie_domain)
     response.delete_cookie("refresh_token", path="/", domain=settings.cookie_domain)
@@ -248,7 +251,6 @@ async def logout(
 @router.get("/verify")
 @limiter.limit("30/minute")
 async def verify_token(
-    request: Request,
     current_user: User = Depends(get_current_user),
 ):
     """Verify if the current access token is valid."""

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/public/auth", tags=["Authentication"])
 
 @router.get("/spotify/login")
 @limiter.limit("10/minute")
-async def spotify_login():
+async def spotify_login(request: Request):
     """
     Initiate Spotify OAuth flow.
     Generates a cryptographically random state value, stores it in a

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -251,6 +251,7 @@ async def logout(
 @router.get("/verify")
 @limiter.limit("30/minute")
 async def verify_token(
+    request: Request,
     current_user: User = Depends(get_current_user),
 ):
     """Verify if the current access token is valid."""

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -96,7 +96,6 @@ async def spotify_callback(
 async def refresh_token(
     request: Request,
     response: Response,
-    db: Session = Depends(get_db),
     redis_client=Depends(get_redis),
 ):
     """

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -220,7 +220,6 @@ async def logout(
     refresh_token_value = request.cookies.get("refresh_token")
     if refresh_token_value:
         try:
-            from backend.core.jwt_utils import decode_refresh_token
             payload = decode_refresh_token(refresh_token_value)
             jti = payload.get("jti")
             exp = payload.get("exp", 0)

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -103,8 +103,11 @@ async def refresh_access_token(refresh_token: str) -> dict:
         user_id = payload.get("user_id")
         old_jti = payload.get("jti")
 
-        if not spotify_id or not user_id:
-            raise ValueError("Invalid token payload — missing sub or user_id")
+        if not spotify_id or not user_id or not old_jti:
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid refresh token payload: missing required claims",
+            )
 
         token_payload = {"sub": spotify_id, "user_id": user_id}
         new_access_token = create_access_token(token_payload)

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -95,8 +95,6 @@ async def refresh_access_token(refresh_token: str) -> dict:
       - old_refresh_jti:   jti of the consumed refresh token (for denylisting)
     """
     try:
-        # decode_refresh_token raises 401 if the token is invalid or has
-        # type != "refresh", so an access token can never sneak through here.
         payload = decode_refresh_token(refresh_token)
 
         spotify_id = payload.get("sub")
@@ -111,16 +109,15 @@ async def refresh_access_token(refresh_token: str) -> dict:
 
         token_payload = {"sub": spotify_id, "user_id": user_id}
         new_access_token = create_access_token(token_payload)
-        new_refresh_token = create_refresh_token(token_payload)   # rotation
+        new_refresh_token = create_refresh_token(token_payload)
 
         return {
             "access_token": new_access_token,
             "refresh_token": new_refresh_token,
-            "old_refresh_jti": old_jti,     # caller denylists this
+            "old_refresh_jti": old_jti,
         }
 
     except HTTPException:
-        # decode_refresh_token already raised a well-formed 401 — re-raise as-is
         raise
     except Exception as e:
         logger.error(f"Unexpected error refreshing access token: {str(e)}")

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -100,6 +100,7 @@ async def refresh_access_token(refresh_token: str) -> dict:
         spotify_id = payload.get("sub")
         user_id = payload.get("user_id")
         old_jti = payload.get("jti")
+        old_exp = payload.get("exp", 0)
 
         if not spotify_id or not user_id or not old_jti:
             raise HTTPException(
@@ -115,6 +116,7 @@ async def refresh_access_token(refresh_token: str) -> dict:
             "access_token": new_access_token,
             "refresh_token": new_refresh_token,
             "old_refresh_jti": old_jti,
+            "old_refresh_exp": old_exp,
         }
 
     except HTTPException:

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -9,6 +9,7 @@ from backend.exceptions.custom_exceptions import (
     SpotifyUserIDMissingError,
     RefreshTokenMissingError,
 )
+from fastapi import HTTPException
 import logging
 
 logger = logging.getLogger(__name__)
@@ -54,11 +55,11 @@ async def handle_spotify_callback(code: str, db: Session):
         )
         db_user = user_service.create_user(db, new_user)
 
-    # Issue our own JWTs — both carry a "type" claim so they can never be
-    # used interchangeably at the decode step.
+    # Issue our own JWTs — both carry a "type" and "jti" claim so they can
+    # never be used interchangeably and can be individually revoked.
     token_payload = {"sub": db_user.spotify_id, "user_id": db_user.id}
-    jwt_token = create_access_token(token_payload)          # embeds type="access"
-    app_refresh_token = create_refresh_token(token_payload) # embeds type="refresh"
+    jwt_token = create_access_token(token_payload)
+    app_refresh_token = create_refresh_token(token_payload)
 
     return jwt_token, app_refresh_token
 
@@ -84,9 +85,14 @@ async def refresh_user_spotify_access_token(db: Session, spotify_id: str) -> Dic
 
 async def refresh_access_token(refresh_token: str) -> dict:
     """
-    Validates our application refresh token and issues a new JWT access token.
-    Uses decode_refresh_token (not decode_access_token) so an access token
-    submitted here is explicitly rejected.
+    Validates our application refresh token, issues a new access token,
+    and rotates the refresh token (issues a new one, returns the old jti
+    so the caller can denylist it).
+
+    Returns a dict with:
+      - access_token:      newly issued access token
+      - refresh_token:     newly issued refresh token (rotation)
+      - old_refresh_jti:   jti of the consumed refresh token (for denylisting)
     """
     try:
         # decode_refresh_token raises 401 if the token is invalid or has
@@ -95,16 +101,24 @@ async def refresh_access_token(refresh_token: str) -> dict:
 
         spotify_id = payload.get("sub")
         user_id = payload.get("user_id")
+        old_jti = payload.get("jti")
 
         if not spotify_id or not user_id:
             raise ValueError("Invalid token payload — missing sub or user_id")
 
-        new_access_token = create_access_token({"sub": spotify_id, "user_id": user_id})
+        token_payload = {"sub": spotify_id, "user_id": user_id}
+        new_access_token = create_access_token(token_payload)
+        new_refresh_token = create_refresh_token(token_payload)   # rotation
 
         return {
             "access_token": new_access_token,
-            "refresh_token": refresh_token,     # refresh token is reused until it expires
+            "refresh_token": new_refresh_token,
+            "old_refresh_jti": old_jti,     # caller denylists this
         }
-    except Exception as e:
-        logger.error(f"Failed to refresh access token: {str(e)}")
+
+    except HTTPException:
+        # decode_refresh_token already raised a well-formed 401 — re-raise as-is
         raise
+    except Exception as e:
+        logger.error(f"Unexpected error refreshing access token: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/services/spotify_auth_service.py
+++ b/backend/services/spotify_auth_service.py
@@ -15,7 +15,7 @@ SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
 SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 
 
-def get_authorize_url(state: str) -> str:       # <-- state is now a required parameter
+def get_authorize_url(state: str) -> str:
     """
     Builds the Spotify authorization URL.
     The caller is responsible for generating a cryptographically random state
@@ -32,7 +32,7 @@ def get_authorize_url(state: str) -> str:       # <-- state is now a required pa
         "response_type": "code",
         "redirect_uri": SPOTIFY_REDIRECT_URI,
         "scope": scope,
-        "state": state,                         # <-- included in redirect
+        "state": state,
     }
     return f"{SPOTIFY_AUTH_URL}?{urlencode(params)}"
 

--- a/backend/services/spotify_auth_service.py
+++ b/backend/services/spotify_auth_service.py
@@ -2,6 +2,10 @@ import httpx
 from typing import Dict, Any
 from urllib.parse import urlencode
 from backend.core.config import settings
+from backend.exceptions.custom_exceptions import SpotifyTokensError
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_authorize_url(state: str) -> str:
     """
@@ -22,43 +26,65 @@ def get_authorize_url(state: str) -> str:
 
 async def get_spotify_tokens(code: str) -> Dict[str, Any]:
     """Exchanges auth code for access/refresh tokens."""
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            settings.spotify_token_url,
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": settings.spotify_redirect_uri,
-                "client_id": settings.spotify_client_id,
-                "client_secret": settings.spotify_client_secret,
-            },
-        )
-        response.raise_for_status()
-        return response.json()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                settings.spotify_token_url,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": settings.spotify_redirect_uri,
+                    "client_id": settings.spotify_client_id,
+                    "client_secret": settings.spotify_client_secret,
+                },
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPStatusError as e:
+        logger.warning("Spotify token exchange failed: %s", e.response.status_code)
+        raise SpotifyTokensError()
+    except httpx.RequestError as e:
+        logger.error("Network error reaching Spotify: %s", e)
+        raise SpotifyTokensError()
 
 
 async def refresh_spotify_token(refresh_token: str) -> Dict[str, Any]:
     """Refreshes an expired access token."""
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            settings.spotify_token_url,
-            data={
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-                "client_id": settings.spotify_client_id,
-                "client_secret": settings.spotify_client_secret,
-            },
-        )
-        response.raise_for_status()
-        return response.json()
-
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                settings.spotify_token_url,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": settings.spotify_client_id,
+                    "client_secret": settings.spotify_client_secret,
+                },
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPStatusError as e:
+        logger.warning("Spotify token exchange failed: %s", e.response.status_code)
+        raise SpotifyTokensError()
+    except httpx.RequestError as e:
+        logger.error("Network error reaching Spotify: %s", e)
+        raise SpotifyTokensError()
+    
 
 async def get_spotify_user_profile(access_token: str) -> Dict[str, Any]:
     """Fetches the current user's Spotify profile."""
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            f"{settings.spotify_api_base_url}/me",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-        response.raise_for_status()
-        return response.json()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{settings.spotify_api_base_url}/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPStatusError as e:
+        logger.warning("Spotify token exchange failed: %s", e.response.status_code)
+        raise SpotifyTokensError()
+    except httpx.RequestError as e:
+        logger.error("Network error reaching Spotify: %s", e)
+        raise SpotifyTokensError()
+    

--- a/backend/services/spotify_auth_service.py
+++ b/backend/services/spotify_auth_service.py
@@ -1,19 +1,7 @@
-import os
 import httpx
-from dotenv import load_dotenv
 from typing import Dict, Any
 from urllib.parse import urlencode
-
-load_dotenv()
-
-SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
-SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
-SPOTIFY_REDIRECT_URI = os.getenv("SPOTIFY_REDIRECT_URI")
-
-SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
-SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
-SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
-
+from backend.core.config import settings
 
 def get_authorize_url(state: str) -> str:
     """
@@ -22,31 +10,27 @@ def get_authorize_url(state: str) -> str:
     value, storing it (e.g. in a short-lived cookie), and passing it here so
     Spotify echoes it back in the callback for CSRF validation.
     """
-    scope = (
-        "user-read-private user-read-email user-top-read "
-        "user-library-read playlist-read-private "
-        "playlist-read-collaborative user-read-recently-played"
-    )
     params = {
-        "client_id": SPOTIFY_CLIENT_ID,
+        "client_id": settings.spotify_client_id,
         "response_type": "code",
-        "redirect_uri": SPOTIFY_REDIRECT_URI,
-        "scope": scope,
+        "redirect_uri": settings.spotify_redirect_uri,
+        "scope": settings.spotify_scopes,
         "state": state,
     }
-    return f"{SPOTIFY_AUTH_URL}?{urlencode(params)}"
+    return f"{settings.spotify_auth_url}?{urlencode(params)}"
 
 
 async def get_spotify_tokens(code: str) -> Dict[str, Any]:
+    """Exchanges auth code for access/refresh tokens."""
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            SPOTIFY_TOKEN_URL,
+            settings.spotify_token_url,
             data={
                 "grant_type": "authorization_code",
                 "code": code,
-                "redirect_uri": SPOTIFY_REDIRECT_URI,
-                "client_id": SPOTIFY_CLIENT_ID,
-                "client_secret": SPOTIFY_CLIENT_SECRET,
+                "redirect_uri": settings.spotify_redirect_uri,
+                "client_id": settings.spotify_client_id,
+                "client_secret": settings.spotify_client_secret,
             },
         )
         response.raise_for_status()
@@ -54,14 +38,15 @@ async def get_spotify_tokens(code: str) -> Dict[str, Any]:
 
 
 async def refresh_spotify_token(refresh_token: str) -> Dict[str, Any]:
+    """Refreshes an expired access token."""
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            SPOTIFY_TOKEN_URL,
+            settings.spotify_token_url,
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": refresh_token,
-                "client_id": SPOTIFY_CLIENT_ID,
-                "client_secret": SPOTIFY_CLIENT_SECRET,
+                "client_id": settings.spotify_client_id,
+                "client_secret": settings.spotify_client_secret,
             },
         )
         response.raise_for_status()
@@ -69,9 +54,10 @@ async def refresh_spotify_token(refresh_token: str) -> Dict[str, Any]:
 
 
 async def get_spotify_user_profile(access_token: str) -> Dict[str, Any]:
+    """Fetches the current user's Spotify profile."""
     async with httpx.AsyncClient() as client:
         response = await client.get(
-            f"{SPOTIFY_API_BASE_URL}/me",
+            f"{settings.spotify_api_base_url}/me",
             headers={"Authorization": f"Bearer {access_token}"},
         )
         response.raise_for_status()

--- a/tests/test_jwt_denylist.py
+++ b/tests/test_jwt_denylist.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from redis.exceptions import ConnectionError, TimeoutError
+from backend.database.redis import JWTDenylist
+
+
+@pytest.fixture
+def mock_redis():
+    r = MagicMock()
+    r.set = AsyncMock(return_value=True)
+    r.exists = AsyncMock(return_value=0)
+    return r
+
+
+# --- add() ---
+
+@pytest.mark.asyncio
+async def test_add_sets_key_with_correct_ttl(mock_redis):
+    denylist = JWTDenylist(mock_redis)
+    result = await denylist.add("abc-123", 300)
+    assert result is True
+    mock_redis.set.assert_awaited_once_with("jwt:deny:abc-123", "1", ex=300)
+
+
+@pytest.mark.asyncio
+async def test_add_clamps_ttl_to_minimum_one(mock_redis):
+    denylist = JWTDenylist(mock_redis)
+    await denylist.add("abc-123", 0)
+    mock_redis.set.assert_awaited_once_with("jwt:deny:abc-123", "1", ex=1)
+
+
+@pytest.mark.asyncio
+async def test_add_returns_false_when_redis_is_none():
+    denylist = JWTDenylist(None)
+    result = await denylist.add("abc-123", 300)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_add_returns_false_on_connection_error(mock_redis):
+    mock_redis.set = AsyncMock(side_effect=ConnectionError("down"))
+    denylist = JWTDenylist(mock_redis)
+    result = await denylist.add("abc-123", 300)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_add_returns_false_on_timeout(mock_redis):
+    mock_redis.set = AsyncMock(side_effect=TimeoutError("timeout"))
+    denylist = JWTDenylist(mock_redis)
+    result = await denylist.add("abc-123", 300)
+    assert result is False
+
+
+# --- is_denied() ---
+
+@pytest.mark.asyncio
+async def test_is_denied_returns_true_when_key_exists(mock_redis):
+    mock_redis.exists = AsyncMock(return_value=1)
+    denylist = JWTDenylist(mock_redis)
+    assert await denylist.is_denied("abc-123") is True
+
+
+@pytest.mark.asyncio
+async def test_is_denied_returns_false_when_key_absent(mock_redis):
+    mock_redis.exists = AsyncMock(return_value=0)
+    denylist = JWTDenylist(mock_redis)
+    assert await denylist.is_denied("abc-123") is False
+
+
+@pytest.mark.asyncio
+async def test_is_denied_fail_open_when_redis_is_none():
+    denylist = JWTDenylist(None)
+    assert await denylist.is_denied("abc-123") is False
+
+
+@pytest.mark.asyncio
+async def test_is_denied_fail_open_on_connection_error(mock_redis):
+    mock_redis.exists = AsyncMock(side_effect=ConnectionError("down"))
+    denylist = JWTDenylist(mock_redis)
+    assert await denylist.is_denied("abc-123") is False
+
+
+@pytest.mark.asyncio
+async def test_is_denied_fail_open_on_timeout(mock_redis):
+    mock_redis.exists = AsyncMock(side_effect=TimeoutError("timeout"))
+    denylist = JWTDenylist(mock_redis)
+    assert await denylist.is_denied("abc-123") is False
+
+
+@pytest.mark.asyncio
+async def test_key_format(mock_redis):
+    """Key must be jwt:deny:{jti} — never jwt:deny: or a different prefix."""
+    denylist = JWTDenylist(mock_redis)
+    await denylist.add("my-jti-value", 60)
+    call_args = mock_redis.set.call_args[0]
+    assert call_args[0] == "jwt:deny:my-jti-value"

--- a/tests/test_jwt_denylist.py
+++ b/tests/test_jwt_denylist.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 from redis.exceptions import ConnectionError, TimeoutError
 from backend.database.redis import JWTDenylist
+import logging
 
 
 @pytest.fixture
@@ -95,3 +96,19 @@ async def test_key_format(mock_redis):
     await denylist.add("my-jti-value", 60)
     call_args = mock_redis.set.call_args[0]
     assert call_args[0] == "jwt:deny:my-jti-value"
+
+@pytest.mark.asyncio
+async def test_is_denied_fail_open_logs_throttled(caplog):
+    """Warning should only fire once per interval, not on every call."""
+    import backend.database.redis as redis_module
+    redis_module._last_deny_warn = 0.0  # reset throttle
+
+    denylist = JWTDenylist(None)
+
+    with caplog.at_level(logging.WARNING, logger="backend.database.redis"):
+        await denylist.is_denied("jti-1")
+        await denylist.is_denied("jti-2")
+        await denylist.is_denied("jti-3")
+
+    warning_count = sum(1 for r in caplog.records if "failing open" in r.message)
+    assert warning_count == 1  # throttled — only fired once


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>fix(auth): harden auth flow — CSRF, token rotation, JWT denylist, logout invalidation</h1>
<h2>Summary</h2>
<p>Fixes five security issues in the authentication layer identified in code review. The most significant change is the introduction of a JWT denylist backed by Redis, which means logout is now immediate rather than waiting for token expiry. Refresh tokens are now rotated on every use.</p>
<hr>
<h2>Changes by file</h2>
<h3><code>jwt_utils.py</code></h3>
<ul>
<li>Injected a <code>jti</code> (<code>uuid4</code>) claim into every issued token via a shared <code>_base_claims</code> helper</li>
<li>Refactored the duplicate decode logic in <code>decode_access_token</code> / <code>decode_refresh_token</code> into a single private <code>_decode_and_validate</code> so the type-enforcement invariant lives in exactly one place</li>
</ul>
<h3><code>redis.py</code></h3>
<ul>
<li>Added <code>JWTDenylist</code> class with <code>add(jti, ttl_seconds)</code> and <code>is_denied(jti)</code> methods</li>
<li>Keys are namespaced as <code>jwt:deny:{jti}</code>; TTL is set to the token's remaining lifetime so Redis self-cleans — no background job or manual purge needed</li>
<li>Both methods are <strong>fail-open</strong>: if Redis is unavailable, <code>is_denied</code> returns <code>False</code> and logs a warning rather than locking all users out</li>
</ul>
<h3><code>dependencies.py</code></h3>
<ul>
<li><code>get_current_user</code> now checks <code>JWTDenylist.is_denied(jti)</code> after decoding the access token and before loading the user from DB</li>
<li>Tightened exception handling: <code>HTTPException</code> from <code>decode_access_token</code> is re-raised directly; unexpected errors become a clean 401 without leaking internal detail</li>
<li>Added <code>redis_client</code> as a dependency so the denylist check is available on every authenticated request</li>
</ul>
<h3><code>auth_service.py</code></h3>
<ul>
<li><code>refresh_access_token</code> now issues a <strong>new refresh token</strong> on every call (rotation) and returns the consumed token's <code>jti</code> as <code>old_refresh_jti</code> so the router can denylist it immediately</li>
<li>Exception handling now explicitly separates <code>HTTPException</code> (re-raise as-is) from unexpected errors (raises 500), preventing raw internal error messages from surfacing to clients</li>
</ul>
<h3><code>auth_router.py</code></h3>
<ul>
<li><strong><code>/spotify/callback</code></strong>: split the state check into two guards — missing cookie returns <code>state_missing</code>, mismatch returns <code>state_mismatch</code>; <code>secrets.compare_digest</code> is no longer called against an empty string fallback</li>
<li><strong><code>/spotify/callback</code></strong>: narrowed the <code>except</code> block — <code>SpotifyTokensError</code> / <code>SpotifyUserIDMissingError</code> are caught and logged as warnings; all other exceptions are caught separately and logged as errors with <code>exc_info=True</code></li>
<li><strong><code>/refresh</code></strong>: denylists the old refresh token jti after rotation; updates both the access token <strong>and</strong> refresh token cookies for cookie-based clients</li>
<li><strong><code>/logout</code></strong>: decodes both the access and refresh token cookies, extracts their <code>jti</code>s, and calls <code>denylist.add()</code> on each with the correct remaining TTL — tokens are revoked immediately rather than at natural expiry</li>
</ul>
<hr>
<h2>Security impact</h2>

Issue | Before | After
-- | -- | --
CSRF state check | compare_digest(state, stored_state or "") silently accepted missing cookie | Explicit null guard returns state_missing before digest comparison
Refresh token reuse | Same token valid for its full 7-day lifetime | Rotated on every /refresh call; old jti denylisted immediately
Refresh cookie on rotation | Access token cookie updated, refresh cookie left stale | Both cookies updated on every successful /refresh
Callback error handling | Single except Exception swallowed all errors at same log level | Spotify errors (warn) separated from server errors (error + traceback)
Logout token invalidation | JWT remained valid until natural expiry (up to 30 min) | Access and refresh jtis denylisted on logout; effective immediately


<hr>
<h2>Failure modes</h2>
<p><strong>Redis down during logout</strong> — <code>JWTDenylist.add</code> returns <code>False</code> and logs a warning. The cookies are still cleared. The issued tokens remain technically valid until expiry. With the default 30-minute access token lifetime this is the accepted trade-off; set <code>ACCESS_TOKEN_EXPIRE_MINUTES</code> lower if the window is too large for your threat model.</p>
<p><strong>Redis down during request auth</strong> — <code>JWTDenylist.is_denied</code> returns <code>False</code> (fail-open). Requests proceed normally. Logged at warning level so it is visible in monitoring.</p>
<hr>
<h2>Testing checklist</h2>
<ul>
<li>[ ] Login → logout → attempt request with old access token cookie returns <code>401 Token has been revoked</code></li>
<li>[ ] Login → logout → attempt <code>/refresh</code> with old refresh token returns <code>401 Token has been revoked</code></li>
<li>[ ] <code>/refresh</code> issues new cookies for both access and refresh tokens in cookie-based flow</li>
<li>[ ] <code>/refresh</code> with an access token (wrong type) returns <code>401 Invalid token type</code></li>
<li>[ ] <code>/spotify/callback</code> with no state cookie redirects to <code>?error=state_missing</code></li>
<li>[ ] <code>/spotify/callback</code> with mismatched state redirects to <code>?error=state_mismatch</code></li>
<li>[ ] Redis unavailable: login, auth, refresh, and logout all degrade gracefully without 500s</li>
<li>[ ] Confirm <code>jwt:deny:*</code> keys in Redis have correct TTLs after logout</li>
</ul></body></html><!--EndFragment-->
</body>
</html>